### PR TITLE
DL-8556 Added auth actions

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActions.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.auth
+
+import play.api.mvc.Results.*
+import play.api.mvc.{Request, Result, Results}
+import play.api.{Configuration, Environment, Logging}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.{AsAgent, CgtPd, MtdIncomeTax}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AuthorisedClient
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.UrlHelper
+import uk.gov.hmrc.auth.core.*
+import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.*
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, ~}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AuthActions @Inject()(env: Environment,
+                            config: Configuration,
+                            val authConnector: AuthConnector,
+                            appConfig: AppConfig)
+  extends AuthorisedFunctions with Logging {
+
+  private val requiredCL = ConfidenceLevel.L250
+
+  def authorisedAsAgent(body: String => Future[Result])
+                       (implicit request: Request[?], hc: HeaderCarrier, ec: ExecutionContext): Future[Result] =
+    authorised(Enrolment(AsAgent) and AuthProviders(GovernmentGateway))
+      .retrieve(authorisedEnrolments) { enrolments =>
+        getArn(enrolments) match {
+          case Some(arn) =>
+            body(arn)
+          case None =>
+            logger.warn("Arn not found for the logged in agent")
+            Future.successful(Forbidden)
+        }
+      }
+      .recover {
+        handleFailure(isAgent = true)
+      }
+
+  def authorisedAsClient(journeyId: Option[String])
+                        (body: AuthorisedClient => Future[Result])
+                        (implicit request: Request[?], hc: HeaderCarrier, ec: ExecutionContext): Future[Result] =
+    authorised(AuthProviders(GovernmentGateway))
+      .retrieve(affinityGroup and confidenceLevel and allEnrolments) {
+        case Some(affinity) ~ confidence ~ enrols =>
+          (affinity, confidence) match {
+            case (AffinityGroup.Individual, cl) =>
+              withConfidenceLevelUplift(cl, enrols) {
+                body(AuthorisedClient(affinity, enrols))
+              }
+            case (AffinityGroup.Organisation, cl) =>
+              if enrols.enrolments.map(_.key).contains(MtdIncomeTax) then withConfidenceLevelUplift(cl, enrols) {
+                body(AuthorisedClient(affinity, enrols))
+              }
+              else body(AuthorisedClient(affinity, enrols))
+            case (AffinityGroup.Agent, _) =>
+              Future.successful(Redirect(routes.AuthorisationController.cannotViewRequest))
+            case (affinityGroup, _) =>
+              logger.warn(s"unknown affinity group: $affinityGroup - cannot determine auth status")
+              Future.successful(Forbidden)
+          }
+        case _ =>
+          logger.warn("the logged in client had no affinity group")
+          Future.successful(Forbidden)
+      }
+      .recover {
+        handleFailure(isAgent = false, journeyId)
+      }
+
+  private def withConfidenceLevelUplift(currentLevel: ConfidenceLevel, enrols: Enrolments)
+                                       (body: => Future[Result])
+                                       (implicit request: Request[?]): Future[Result] = {
+    // APB-4856: Clients with only CGT enrol dont need to go through IV
+    val isCgtOnlyClient: Boolean = {
+      enrols.enrolments.map(_.key).intersect(appConfig.supportedServices) == Set(CgtPd)
+    }
+
+    if currentLevel >= requiredCL || isCgtOnlyClient then {
+      body
+    } else if request.method == "GET" then {
+      redirectToIdentityVerification()
+    } else {
+      Future.successful(Redirect(routes.AuthorisationController.cannotConfirmIdentity().url))
+    }
+  }
+
+  private def successUrl(implicit request: Request[?]) =
+    appConfig.appExternalUrl + request.uri
+
+  private def redirectToIdentityVerification()(implicit request: Request[?]) = {
+    val failureUrl = appConfig.appExternalUrl +
+      routes.AuthorisationController.cannotConfirmIdentity(continueUrl = Some(RedirectUrl(successUrl))).url
+
+    Future.successful(Redirect(UrlHelper.addParamsToUrl(
+      appConfig.ivUpliftUrl,
+      "origin" -> Some(appConfig.appName),
+      "confidenceLevel" -> Some(requiredCL.toString),
+      "completionURL" -> Some(successUrl),
+      "failureURL" -> Some(failureUrl)
+    )))
+  }
+
+  private def getArn(enrolments: Enrolments) =
+    for
+      enrolment <- enrolments.getEnrolment(AsAgent)
+      identifier <- enrolment.getIdentifier("AgentReferenceNumber")
+    yield identifier.value
+
+  private def handleFailure(isAgent: Boolean, journeyId: Option[String] = None)
+                           (implicit request: Request[?]): PartialFunction[Throwable, Result] = {
+    case _: NoActiveSession =>
+      val continueUrl = if journeyId.isEmpty then {
+        successUrl
+      } else {
+        UrlHelper.addParamsToUrl(
+          successUrl,
+          "clientInvitationJourney" -> journeyId
+        )
+      }
+      Redirect(UrlHelper.addParamsToUrl(
+        appConfig.signInUrl,
+        "origin" -> Some(appConfig.appName),
+        "continue_url" -> Some(continueUrl)
+      ))
+    case _: InsufficientEnrolments =>
+      logger.warn(s"Logged in user does not have required enrolments")
+      if isAgent then Redirect(appConfig.subscriptionUrl) else Forbidden
+    case _: UnsupportedAuthProvider =>
+      logger.warn(s"user logged in with unsupported auth provider")
+      Forbidden
+  }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActions.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.auth
 
+import play.api.Logging
 import play.api.mvc.Results.*
-import play.api.mvc.{Request, Result, Results}
-import play.api.{Configuration, Environment, Logging}
+import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.{AsAgent, CgtPd, MtdIncomeTax}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
@@ -27,7 +27,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.UrlHelper
 import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.*
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, ~}
+import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 
@@ -35,9 +35,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class AuthActions @Inject()(env: Environment,
-                            config: Configuration,
-                            val authConnector: AuthConnector,
+class AuthActions @Inject()(val authConnector: AuthConnector,
                             appConfig: AppConfig)
   extends AuthorisedFunctions with Logging {
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
@@ -22,5 +22,46 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
 class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration):
+  // Base Urls
+  val ivFrontendBaseUrl: String = baseUrl("identity-verification-frontend")
+
+  // Urls
+  val appExternalUrl: String = getConfString("agent-client-relationships-frontend.external-url")
+  val asaFrontendExternalUrl: String = getConfString("agent-services-account-frontend.external-url")
+  val asaAccountLimitedUrl: String = asaFrontendExternalUrl + "/agent-services-account/account-limited"
+  val asaHomeUrl: String = asaFrontendExternalUrl + "/agent-services-account/home"
+  val ivUpliftUrl: String = getConfString("identity-verification-uplift.url")
+  val signInUrl: String = getString("bas-gateway.url")
+  val subscriptionUrl: String = getConfString("agent-subscription-frontend.subscription-url")
+  
+  // Feature Flags
   val welshLanguageSupportEnabled: Boolean = config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
-  val agentServicesAccountHomeUrl = servicesConfig.getString("agent-services-account-frontend-home-url")
+
+  // Service config
+  val appName: String = getString("appName")
+  val timeoutDialogTimeoutSeconds: Int = servicesConfig.getInt("timeoutDialog.timeout-seconds")
+  val allowedRedirectHosts: Set[String] = config.getOptional[Seq[String]]("allowed-redirect-hosts").getOrElse(Nil).toSet
+
+  // Stub for supported services to be replaced when decision on how to handle this is reached
+  val supportedServices: Set[String] =
+    Set(
+      "HMRC-MTD-IT",
+      "PERSONAL-INCOME-RECORD",
+      "HMRC-MTD-VAT",
+      "HMRC-TERS-ORG",
+      "HMRC-TERSNT-ORG",
+      "HMRC-CGT-PD",
+      "HMRC-PPT-ORG",
+      "HMRC-CBC-ORG",
+      "HMRC-CBC-NONUK-ORG",
+      "HMRC-PILLAR2-ORG"
+    )
+  
+  private def getString(key: String) = servicesConfig.getString(key)
+  
+  // For config contained in 'microservice.services'
+  private def getConfString(key: String) =
+    servicesConfig.getConfString(key, throw new RuntimeException(s"config $key not found"))
+
+  private def baseUrl(serviceName: String) = servicesConfig.baseUrl(serviceName)
+

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/Constants.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/Constants.scala
@@ -18,10 +18,14 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.config
 
 object Constants {
   
+  // agent enrolment
+  val AsAgent = "HMRC-AS-AGENT"
+  
   // client services
   val MtdIncomeTax = "HMRC-MTD-IT"
   val PersonalIncome = "PERSONAL-INCOME-RECORD"
   val PlasticPackaging = "HMRC-PPT-ORG"
+  val CgtPd = "HMRC-CGT-PD"
 
   // dates
   val Year = "year"

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/IdentityVerificationConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/IdentityVerificationConnector.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.connectors
+
+import com.codahale.metrics.MetricRegistry
+import play.api.Logging
+import play.api.http.Status.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.IVResult
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.HttpAPIMonitor
+import uk.gov.hmrc.http.*
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.play.bootstrap.metrics.Metrics
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class IdentityVerificationConnector @Inject()(http: HttpClientV2)
+                                             (implicit appConfig: AppConfig,
+                                              val metrics: Metrics,
+                                              val ec: ExecutionContext)
+  extends HttpAPIMonitor with Logging {
+
+  private[connectors] def getIVResultUrl(journeyId: String) =
+    s"${appConfig.ivFrontendBaseUrl}/mdtp/journey/journeyId/$journeyId"
+
+  def getIVResult(journeyId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[IVResult]] =
+    monitor("ConsumedAPI-Client-Get-IVResult-GET") {
+      http
+        .get(url"${getIVResultUrl(journeyId)}")
+        .execute[HttpResponse]
+        .map { response =>
+          response.status match {
+            case OK =>
+              val result = (response.json \ "result").as[IVResult]
+              logger.warn(s"identity verification returned result $result for journeyId $journeyId")
+              Some(result)
+            case NOT_FOUND => None
+          }
+        }
+    }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/IdentityVerificationConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/IdentityVerificationConnector.scala
@@ -20,7 +20,7 @@ import com.codahale.metrics.MetricRegistry
 import play.api.Logging
 import play.api.http.Status.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.IVResult
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.IvResult
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.HttpAPIMonitor
 import uk.gov.hmrc.http.*
 import uk.gov.hmrc.http.HttpReads.Implicits.*
@@ -40,7 +40,7 @@ class IdentityVerificationConnector @Inject()(http: HttpClientV2)
   private[connectors] def getIVResultUrl(journeyId: String) =
     s"${appConfig.ivFrontendBaseUrl}/mdtp/journey/journeyId/$journeyId"
 
-  def getIVResult(journeyId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[IVResult]] =
+  def getIVResult(journeyId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[IvResult]] =
     monitor("ConsumedAPI-Client-Get-IVResult-GET") {
       http
         .get(url"${getIVResultUrl(journeyId)}")
@@ -48,7 +48,7 @@ class IdentityVerificationConnector @Inject()(http: HttpClientV2)
         .map { response =>
           response.status match {
             case OK =>
-              val result = (response.json \ "result").as[IVResult]
+              val result = (response.json \ "result").as[IvResult]
               logger.warn(s"identity verification returned result $result for journeyId $journeyId")
               Some(result)
             case NOT_FOUND => None

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationController.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.IdentityVerificationConnector
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.UrlHelper
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.TimedOut
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.auth.*
+import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, OnlyRelative, RedirectUrl}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AuthorisationController @Inject()(mcc: MessagesControllerComponents,
+                                        identityVerificationConnector: IdentityVerificationConnector,
+                                        cannotConfirmIdentityView: CannotConfirmIdentity,
+                                        errorCannotViewRequestView: ErrorCannotViewRequest,
+                                        notAuthorisedAsClientView: NotAuthorisedAsClient,
+                                        ivTechDifficultiesView: IvTechDifficulties,
+                                        ivLockedOutView: IvLockedOut,
+                                        timedOutView: TimedOut)
+                                       (implicit executionContext: ExecutionContext,
+                                        appConfig: AppConfig)
+  extends FrontendController(mcc) with I18nSupport:
+
+  def cannotViewRequest: Action[AnyContent] = Action.async:
+    implicit request =>
+      Future.successful(NotImplemented)
+  //TODO should return errorCannotViewRequestView if the client type is known, otherwise notAuthorisedAsClientView
+
+  def cannotConfirmIdentity(journeyId: Option[String], continueUrl: Option[RedirectUrl]): Action[AnyContent] = Action.async:
+    implicit request =>
+      val url = continueUrl.map(UrlHelper.validateRedirectUrl)
+      journeyId
+        .fold(
+          Future.successful(Forbidden(cannotConfirmIdentityView(url)))
+        )(id =>
+          identityVerificationConnector
+            .getIVResult(id)
+            .map {
+              case Some(TechnicalIssue) =>
+                Forbidden(ivTechDifficultiesView())
+              case Some(FailedMatching | FailedDirectorCheck | FailedIV | InsufficientEvidence) =>
+                Forbidden(cannotConfirmIdentityView(url))
+              case Some(UserAborted | TimedOut) => Redirect(routes.AuthorisationController.handleIVTimeout(continueUrl))
+              case Some(LockedOut) => Redirect(routes.AuthorisationController.lockedOut)
+              case _ => Forbidden(cannotConfirmIdentityView(url))
+            }
+        )
+
+  def handleIVTimeout(continueUrl: Option[RedirectUrl]): Action[AnyContent] = Action.async:
+    implicit request =>
+      Future.successful(Forbidden(timedOutView(continueUrl.map(UrlHelper.validateRedirectUrl), isAgent = false)))
+
+  def lockedOut: Action[AnyContent] = Action.async:
+    implicit request =>
+      Future.successful(Forbidden(ivLockedOutView()))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/TestAuthController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/TestAuthController.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, MessagesRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.auth.AuthActions
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TestAuthController @Inject()(mcc: MessagesControllerComponents,
+                                   authActions: AuthActions)
+                                  (implicit executionContext: ExecutionContext)
+  extends FrontendController(mcc):
+
+  def agent: Action[AnyContent] = Action.async:
+    request =>
+      given MessagesRequest[AnyContent] = request
+
+      authActions.authorisedAsAgent { agent =>
+        Future.successful(Ok(s"Auth passed for :$agent"))
+      }
+
+  def client: Action[AnyContent] = Action.async:
+    request =>
+      given MessagesRequest[AnyContent] = request
+
+      authActions.authorisedAsClient(Some("id")) { client =>
+        Future.successful(Ok(s"Auth passed for :${client.toString}"))
+      }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/CheckYourAnswersController.scala
@@ -43,12 +43,12 @@ class CheckYourAnswersController @Inject()(mcc: MessagesControllerComponents,
     request =>
       given MessagesRequest[AnyContent] = request
 
-      val answersFromSession = for {
+      val answersFromSession = for
         clientType <- createInvitationService.getAnswerFromSession(ClientTypeFieldName)
         clientService <- createInvitationService.getAnswerFromSession(ClientServiceFieldName)
         clientName <- createInvitationService.getAnswerFromSession(ClientNameFieldName)
         agentType <- createInvitationService.getAnswerFromSession(AgentTypeFieldName)
-      } yield (clientType, clientService, clientName, agentType)
+      yield (clientType, clientService, clientName, agentType)
       
       answersFromSession.map { answers =>
         Ok(view(previousPageUrl, clientType = answers._1, clientService = answers._2, clientName = answers._3, agentType = answers._4))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/ConfirmClientController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/ConfirmClientController.scala
@@ -71,7 +71,7 @@ class ConfirmClientController @Inject()(mcc: MessagesControllerComponents,
             }
           },
           clientConfirmed => {
-            if (clientConfirmed) {
+            if clientConfirmed then {
               createInvitationService.saveAnswerInSession(ConfirmationFieldName, clientConfirmed.toString).map { _ =>
                 Redirect(nextPageUrl)
               }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/EnterClientDetailsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/EnterClientDetailsController.scala
@@ -38,7 +38,7 @@ class EnterClientDetailsController @Inject()(mcc: MessagesControllerComponents,
   private def previousPageUrl(clientService: String, currentFieldName: String): String = {
     val firstFieldName = clientServiceConfig.firstClientDetailsFieldFor(clientService).name
 
-    if (currentFieldName.equalsIgnoreCase(firstFieldName)) { // this is field 1/1 or 1/2
+    if currentFieldName.equalsIgnoreCase(firstFieldName) then { // this is field 1/1 or 1/2
       routes.SelectClientServiceController.show.url
     } else { // this is field 2/2
       routes.EnterClientDetailsController.show(firstFieldName).url
@@ -55,7 +55,7 @@ class EnterClientDetailsController @Inject()(mcc: MessagesControllerComponents,
         val clientDetailsFieldConfiguration = clientServiceConfig.fieldConfigurationFor(clientService, fieldName)
 
         createInvitationService.getAnswerFromSession(fieldName).map { fieldAnswer =>
-          val form = if (fieldAnswer.nonEmpty) {
+          val form = if fieldAnswer.nonEmpty then {
             EnterClientDetailsForm.form(clientDetailsFieldConfiguration).fill(fieldAnswer)
           } else {
             EnterClientDetailsForm.form(clientDetailsFieldConfiguration)
@@ -80,7 +80,7 @@ class EnterClientDetailsController @Inject()(mcc: MessagesControllerComponents,
             createInvitationService.saveAnswerInSession(fieldName, clientDetailsData).flatMap { _ =>
               val lastFieldName = clientServiceConfig.clientDetailsFor(clientService).last.name
 
-              if (fieldName.equalsIgnoreCase(lastFieldName)) { // this is field 1/1 or 2/2
+              if fieldName.equalsIgnoreCase(lastFieldName) then { // this is field 1/1 or 2/2
                 agentClientRelationshipsConnector.getClientDetails.flatMap { clientName =>
                   createInvitationService.saveAnswerInSession(ClientNameFieldName, clientName).map { _ =>
                     Redirect(nextPageUrl)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/InvitationCreatedController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/InvitationCreatedController.scala
@@ -54,6 +54,6 @@ class InvitationCreatedController @Inject()(mcc: MessagesControllerComponents,
           invitationExpiryDate = invitationDetails.expiryDate.format(formatter),
           daysUntilInvitationExpires = ChronoUnit.DAYS.between(LocalDate.now(), invitationDetails.expiryDate).toString,
           agentEmail = agentEmail,
-          agentHomeLink = appConfig.agentServicesAccountHomeUrl
+          agentHomeLink = appConfig.asaHomeUrl
         ))
       }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/SelectClientTypeController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/createInvitation/SelectClientTypeController.scala
@@ -36,7 +36,7 @@ class SelectClientTypeController @Inject()(mcc: MessagesControllerComponents,
                                            serviceConfig: ClientServiceConfigurationService
                                           )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc):
 
-  private def previousPageUrl(cya: Boolean = false): String = if (cya) routes.CheckYourAnswersController.show.url else appConfig.agentServicesAccountHomeUrl
+  private def previousPageUrl(cya: Boolean = false): String = if cya then routes.CheckYourAnswersController.show.url else appConfig.asaHomeUrl
   private lazy val nextPageUrl: String = routes.SelectClientServiceController.show.url
   private def formSubmitUrl(cya: Boolean = false): Call = routes.SelectClientTypeController.onSubmit(cya)
   

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AuthorisedClient.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AuthorisedClient.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models
+
+import uk.gov.hmrc.auth.core.AffinityGroup.{Individual, Organisation}
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
+
+import scala.collection.immutable.Set
+
+case class AuthorisedClient(affinityGroup: AffinityGroup, enrolments: Enrolments)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/IVResult.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/IVResult.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models
+
+import play.api.libs.json._
+import uk.gov.hmrc.http.BadRequestException
+
+sealed trait IVResult {
+  val value: String
+}
+
+case object Success extends IVResult { override val value = "Success" }
+case object Incomplete extends IVResult { override val value = "Incomplete" }
+case object PreconditionFailed extends IVResult { override val value = "PreconditionFailed" }
+case object LockedOut extends IVResult { override val value = "LockedOut" }
+case object InsufficientEvidence extends IVResult { override val value = "InsufficientEvidence" }
+case object FailedMatching extends IVResult { override val value = "FailedMatching" }
+case object TechnicalIssue extends IVResult { override val value = "TechnicalIssue" }
+case object UserAborted extends IVResult { override val value = "UserAborted" }
+case object TimedOut extends IVResult { override val value = "Timeout" }
+case object FailedIV extends IVResult { override val value = "FailedIV" }
+case object FailedDirectorCheck extends IVResult { override val value = "FailedDirectorCheck" }
+
+object IVResult {
+  def apply(str: String): IVResult = str match {
+    case Success.value              => Success
+    case Incomplete.value           => Incomplete
+    case PreconditionFailed.value   => PreconditionFailed
+    case LockedOut.value            => LockedOut
+    case InsufficientEvidence.value => InsufficientEvidence
+    case FailedMatching.value       => FailedMatching
+    case TechnicalIssue.value       => TechnicalIssue
+    case UserAborted.value          => UserAborted
+    case TimedOut.value             => TimedOut
+    case FailedIV.value             => FailedIV
+    case FailedDirectorCheck.value  => FailedDirectorCheck
+    case _                          => throw new BadRequestException("strange value for IVReason")
+  }
+
+  def unapply(reason: IVResult): Option[String] = reason match {
+    case Success              => Some("Success")
+    case Incomplete           => Some("Incomplete")
+    case PreconditionFailed   => Some("PreconditionFailed")
+    case LockedOut            => Some("LockedOut")
+    case InsufficientEvidence => Some("InsufficientEvidence")
+    case FailedMatching       => Some("FailedMatching")
+    case TechnicalIssue       => Some("TechnicalIssue")
+    case UserAborted          => Some("UserAborted")
+    case TimedOut             => Some("Timeout")
+    case FailedIV             => Some("FailedIV")
+    case FailedDirectorCheck  => Some("FailedDirectorCheck")
+  }
+
+  implicit val reads: Reads[IVResult] = new Reads[IVResult] {
+    override def reads(json: JsValue): JsResult[IVResult] =
+      json match {
+        case JsString(Success.value)              => JsSuccess(Success)
+        case JsString(Incomplete.value)           => JsSuccess(Incomplete)
+        case JsString(PreconditionFailed.value)   => JsSuccess(PreconditionFailed)
+        case JsString(LockedOut.value)            => JsSuccess(LockedOut)
+        case JsString(InsufficientEvidence.value) => JsSuccess(InsufficientEvidence)
+        case JsString(FailedMatching.value)       => JsSuccess(FailedMatching)
+        case JsString(TechnicalIssue.value)       => JsSuccess(TechnicalIssue)
+        case JsString(UserAborted.value)          => JsSuccess(UserAborted)
+        case JsString(TimedOut.value)             => JsSuccess(TimedOut)
+        case JsString(FailedIV.value)             => JsSuccess(FailedIV)
+        case JsString(FailedDirectorCheck.value)  => JsSuccess(FailedDirectorCheck)
+        case invalid                              => JsError(s"invalid IVResult value found: $invalid")
+      }
+  }
+
+  implicit val writes: Writes[IVResult] = new Writes[IVResult] {
+    override def writes(o: IVResult): JsValue = JsString(o.value)
+  }
+
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/IvResult.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/IvResult.scala
@@ -19,24 +19,24 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.models
 import play.api.libs.json._
 import uk.gov.hmrc.http.BadRequestException
 
-sealed trait IVResult {
+sealed trait IvResult {
   val value: String
 }
 
-case object Success extends IVResult { override val value = "Success" }
-case object Incomplete extends IVResult { override val value = "Incomplete" }
-case object PreconditionFailed extends IVResult { override val value = "PreconditionFailed" }
-case object LockedOut extends IVResult { override val value = "LockedOut" }
-case object InsufficientEvidence extends IVResult { override val value = "InsufficientEvidence" }
-case object FailedMatching extends IVResult { override val value = "FailedMatching" }
-case object TechnicalIssue extends IVResult { override val value = "TechnicalIssue" }
-case object UserAborted extends IVResult { override val value = "UserAborted" }
-case object TimedOut extends IVResult { override val value = "Timeout" }
-case object FailedIV extends IVResult { override val value = "FailedIV" }
-case object FailedDirectorCheck extends IVResult { override val value = "FailedDirectorCheck" }
+case object Success extends IvResult { override val value = "Success" }
+case object Incomplete extends IvResult { override val value = "Incomplete" }
+case object PreconditionFailed extends IvResult { override val value = "PreconditionFailed" }
+case object LockedOut extends IvResult { override val value = "LockedOut" }
+case object InsufficientEvidence extends IvResult { override val value = "InsufficientEvidence" }
+case object FailedMatching extends IvResult { override val value = "FailedMatching" }
+case object TechnicalIssue extends IvResult { override val value = "TechnicalIssue" }
+case object UserAborted extends IvResult { override val value = "UserAborted" }
+case object TimedOut extends IvResult { override val value = "Timeout" }
+case object FailedIv extends IvResult { override val value = "FailedIV" }
+case object FailedDirectorCheck extends IvResult { override val value = "FailedDirectorCheck" }
 
-object IVResult {
-  def apply(str: String): IVResult = str match {
+object IvResult {
+  def apply(str: String): IvResult = str match {
     case Success.value              => Success
     case Incomplete.value           => Incomplete
     case PreconditionFailed.value   => PreconditionFailed
@@ -46,12 +46,12 @@ object IVResult {
     case TechnicalIssue.value       => TechnicalIssue
     case UserAborted.value          => UserAborted
     case TimedOut.value             => TimedOut
-    case FailedIV.value             => FailedIV
+    case FailedIv.value             => FailedIv
     case FailedDirectorCheck.value  => FailedDirectorCheck
     case _                          => throw new BadRequestException("strange value for IVReason")
   }
 
-  def unapply(reason: IVResult): Option[String] = reason match {
+  def unapply(reason: IvResult): Option[String] = reason match {
     case Success              => Some("Success")
     case Incomplete           => Some("Incomplete")
     case PreconditionFailed   => Some("PreconditionFailed")
@@ -61,12 +61,12 @@ object IVResult {
     case TechnicalIssue       => Some("TechnicalIssue")
     case UserAborted          => Some("UserAborted")
     case TimedOut             => Some("Timeout")
-    case FailedIV             => Some("FailedIV")
+    case FailedIv             => Some("FailedIV")
     case FailedDirectorCheck  => Some("FailedDirectorCheck")
   }
 
-  implicit val reads: Reads[IVResult] = new Reads[IVResult] {
-    override def reads(json: JsValue): JsResult[IVResult] =
+  implicit val reads: Reads[IvResult] = new Reads[IvResult] {
+    override def reads(json: JsValue): JsResult[IvResult] =
       json match {
         case JsString(Success.value)              => JsSuccess(Success)
         case JsString(Incomplete.value)           => JsSuccess(Incomplete)
@@ -77,14 +77,14 @@ object IVResult {
         case JsString(TechnicalIssue.value)       => JsSuccess(TechnicalIssue)
         case JsString(UserAborted.value)          => JsSuccess(UserAborted)
         case JsString(TimedOut.value)             => JsSuccess(TimedOut)
-        case JsString(FailedIV.value)             => JsSuccess(FailedIV)
+        case JsString(FailedIv.value)             => JsSuccess(FailedIv)
         case JsString(FailedDirectorCheck.value)  => JsSuccess(FailedDirectorCheck)
         case invalid                              => JsError(s"invalid IVResult value found: $invalid")
       }
   }
 
-  implicit val writes: Writes[IVResult] = new Writes[IVResult] {
-    override def writes(o: IVResult): JsValue = JsString(o.value)
+  implicit val writes: Writes[IvResult] = new Writes[IvResult] {
+    override def writes(o: IvResult): JsValue = JsString(o.value)
   }
 
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/DateFormFieldHelper.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/DateFormFieldHelper.scala
@@ -45,7 +45,7 @@ object DateFormFieldHelper extends FormFieldHelper {
     ).verifying(validateDate(formMessageKey))
       .transform[String](
         { case (y, m, d) =>
-          if (y.isEmpty || m.isEmpty || d.isEmpty) ""
+          if y.isEmpty || m.isEmpty || d.isEmpty then ""
           else LocalDate.of(y.toInt, m.toInt, d.toInt).format(dateFormatter)
         },
         date =>
@@ -70,7 +70,7 @@ object DateFormFieldHelper extends FormFieldHelper {
         case (false, true, false) => invalidMandatoryField(s"$formMessageKey.$Day-$Year", s"$Day-$Year")
         case (false, false, true) => invalidMandatoryField(s"$formMessageKey.$Month-$Year", s"$Month-$Year")
         case (true, true, true) =>
-          if (parseDate(s"${s._1}-${s._2}-${s._3}")) Valid
+          if parseDate(s"${s._1}-${s._2}-${s._3}") then Valid
           else invalidInput(formMessageKey, s"$Day-$Month-$Year")
       }
     }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/CreateInvitationService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/CreateInvitationService.scala
@@ -38,12 +38,12 @@ class CreateInvitationService @Inject()(createInvitationJourneyRepository: Creat
   }
 
   def getCheckYourAnswersDataFromSession(implicit request: Request[Any]): Future[(String, String, String, String)] = {
-    for {
+    for
       clientType <- getAnswerFromSession(ClientTypeFieldName)
       clientService <- getAnswerFromSession(ClientServiceFieldName)
       clientName <- getAnswerFromSession(ClientNameFieldName)
       agentType <- getAnswerFromSession(AgentTypeFieldName)
-    } yield (clientType, clientService, clientName, agentType)
+    yield (clientType, clientService, clientName, agentType)
   }
 
   def deleteAllAnswersInSession(implicit request: Request[Any]): Future[Unit] = {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/HttpAPIMonitor.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/HttpAPIMonitor.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.utils
+
+import uk.gov.hmrc.play.bootstrap.metrics.Metrics
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait HttpAPIMonitor {
+
+  val metrics: Metrics
+  implicit val ec: ExecutionContext
+  def monitor[A](str: String)(f: => Future[A]): Future[A] = {
+    val timerContext = metrics.defaultRegistry.timer(s"Timer-$str").time()
+    f.andThen { case _ => timerContext.stop() }
+  }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/UrlHelper.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/UrlHelper.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.utils
+
+import play.api.{Environment, Mode}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, OnlyRelative, RedirectUrl}
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl.idFunctor
+
+import java.net.{URI, URLEncoder}
+
+object UrlHelper {
+
+  def addParamsToUrl(url: String, params: (String, Option[String])*): String = {
+    val query = params.collect { case (key, Some(value)) => s"$key=${URLEncoder.encode(value, "UTF-8")}" } mkString "&"
+    if query.isEmpty then {
+      url
+    } else if url.endsWith("?") || url.endsWith("&") then {
+      url + query
+    } else {
+      val join = if url.contains("?") then "&" else "?"
+      url + join + query
+    }
+  }
+
+  def validateRedirectUrl(redirectUrl: RedirectUrl)(implicit appConfig: AppConfig): String =
+    if RedirectUrl.isRelativeUrl(redirectUrl.unsafeValue) then {
+      redirectUrl.get(OnlyRelative).url
+    } else {
+      redirectUrl.get(AbsoluteWithHostnameFromAllowlist(appConfig.allowedRedirectHosts)).url
+    }
+
+
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/UrlHelper.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/UrlHelper.scala
@@ -16,12 +16,11 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.utils
 
-import play.api.{Environment, Mode}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, OnlyRelative, RedirectUrl}
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl.idFunctor
+import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, OnlyRelative, RedirectUrl}
 
-import java.net.{URI, URLEncoder}
+import java.net.URLEncoder
 
 object UrlHelper {
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TimedOut.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TimedOut.scala.html
@@ -1,0 +1,56 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+
+@this(
+        layout: Layout,
+        h1: h1,
+        p: p,
+        a: a,
+        govukButton: GovukButton,
+        appConfig: AppConfig
+)
+
+@(continueUrl: Option[String], isAgent: Boolean)(implicit request: Request[?], messages: Messages)
+
+@timeString = @{
+    val timeout = appConfig.timeoutDialogTimeoutSeconds
+    if(timeout < 60) s"$timeout ${messages("timed-out.seconds")}" else s"${timeout / 60} ${messages("timed-out.minutes")}"
+}
+
+@layout(
+    pageTitle = messages("timed-out.header"),
+    serviceName = Some(if(isAgent) messages("service.name.agents.auth") else messages("service.name.clients"))
+) {
+
+    @h1(messages("timed-out.header"))
+    @p() { @messages("timed-out.p1", timeString) }
+
+    @continueUrl.map { url =>
+        @if(isAgent) {
+            @p() {
+                @a(url, messages("timed-out.p2.link"))
+                @messages("timed-out.p2.end")
+            }
+        } else {
+            @govukButton(Button(
+                content = Text(messages("timed-out.button")),
+                href = Some(url)
+            ))
+        }
+    }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOut.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOut.scala.html
@@ -21,11 +21,10 @@
         h1: h1,
         p: p,
         a: a,
-        govukButton: GovukButton,
-        appConfig: AppConfig
+        govukButton: GovukButton
 )
 
-@(continueUrl: Option[String], isAgent: Boolean)(implicit request: Request[?], messages: Messages)
+@(continueUrl: Option[String], isAgent: Boolean)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @timeString = @{
     val timeout = appConfig.timeoutDialogTimeoutSeconds

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentity.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentity.scala.html
@@ -14,23 +14,19 @@
  * limitations under the License.
  *@
 
-@import play.api.Configuration
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.*
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.*
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
 
 @this(
         layout: Layout,
         govukButton: GovukButton,
         h1: h1,
-        p: p,
-        appConfig: AppConfig
+        p: p
 )
 
-@(tryAgainUrl: Option[String])(implicit request: Request[?], messages: Messages)
+@(tryAgainUrl: Option[String])(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @layout(
     pageTitle = messages("cannot-confirm-identity.header"),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentity.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentity.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.Configuration
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.*
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.*
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        h1: h1,
+        p: p,
+        appConfig: AppConfig
+)
+
+@(tryAgainUrl: Option[String])(implicit request: Request[?], messages: Messages)
+
+@layout(
+    pageTitle = messages("cannot-confirm-identity.header"),
+    serviceName = Some(messages("service.name.clients"))
+) {
+    @h1(messages("cannot-confirm-identity.header"))
+    @p() { @messages("cannot-confirm-identity.p1") }
+    @p() { @messages("cannot-confirm-identity.p2") }
+
+    @tryAgainUrl.map { url =>
+        @govukButton(Button(
+            content = Text(messages("try-again.button")),
+            href = Some(url)
+        ))
+    }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequest.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequest.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.Configuration
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        h1: h1,
+        p: p,
+        appConfig: AppConfig
+)
+
+@(clientType: String)(implicit request: Request[?], messages: Messages)
+
+@layout(
+    pageTitle = messages("error.cannot-view-request.title"),
+    serviceName = Some(messages("service.name.clients"))
+) {
+
+    @h1(messages("error.cannot-view-request.header"))
+
+    @p(){ @messages("error.cannot-view-request.p1") }
+    @p(){ @messages("error.cannot-view-request.p2") }
+    @p(){ @messages("error.cannot-view-request.p3", messages(s"error.cannot-view-request.client-type.$clientType")) }
+
+    @govukButton(Button(
+        content = Text(messages("error.cannot-view-request.button")),
+        href = Some(appConfig.signInUrl)
+    ))
+
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequest.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequest.scala.html
@@ -14,18 +14,16 @@
  * limitations under the License.
  *@
 
-@import play.api.Configuration
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 
 @this(
         layout: Layout,
         govukButton: GovukButton,
         h1: h1,
-        p: p,
-        appConfig: AppConfig
+        p: p
 )
 
-@(clientType: String)(implicit request: Request[?], messages: Messages)
+@(clientType: String)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @layout(
     pageTitle = messages("error.cannot-view-request.title"),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOut.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOut.scala.html
@@ -14,23 +14,19 @@
  * limitations under the License.
  *@
 
-@import play.api.Configuration
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.*
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.*
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
 
 @this(
         layout: Layout,
         govukButton: GovukButton,
         h1: h1,
-        p: p,
-        appConfig: AppConfig
+        p: p
 )
 
-@()(implicit request: Request[?], messages: Messages)
+@()(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @layout(
     pageTitle = messages("locked-out.header"),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOut.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOut.scala.html
@@ -1,0 +1,43 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.Configuration
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.*
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.*
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        h1: h1,
+        p: p,
+        appConfig: AppConfig
+)
+
+@()(implicit request: Request[?], messages: Messages)
+
+@layout(
+    pageTitle = messages("locked-out.header"),
+    serviceName = Some(messages("service.name.clients"))
+) {
+    @h1(messages("locked-out.header"))
+    @p() { @messages("locked-out.p1") }
+    @p() { @messages("locked-out.p2") }
+    @p() { @messages("locked-out.p3") }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficulties.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficulties.scala.html
@@ -1,0 +1,51 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.Configuration
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.*
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.*
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        h1: h1,
+        p: p,
+        a: a,
+        appConfig: AppConfig
+)
+
+@()(implicit request: Request[?], messages: Messages)
+
+@layout(
+    pageTitle = messages("technical-issues.header"),
+    serviceName = Some(messages("service.name.clients"))
+) {
+    @h1(messages("technical-issues.header"))
+    @p() { @messages("technical-issues.p1") }
+    @p() { @messages("technical-issues.p2") }
+    @p() {
+        @a(messages("technical-issues.vat-url"), messages("technical-issues.vat.link"))
+        @messages("technical-issues.vat.end")
+    }
+    @p() {
+        @a(messages("technical-issues.sa-url"), messages("technical-issues.it.link"))
+        @messages("technical-issues.it.end")
+    }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficulties.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficulties.scala.html
@@ -14,24 +14,20 @@
  * limitations under the License.
  *@
 
-@import play.api.Configuration
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.*
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.*
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
 
 @this(
         layout: Layout,
         govukButton: GovukButton,
         h1: h1,
         p: p,
-        a: a,
-        appConfig: AppConfig
+        a: a
 )
 
-@()(implicit request: Request[?], messages: Messages)
+@()(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @layout(
     pageTitle = messages("technical-issues.header"),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClient.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClient.scala.html
@@ -21,11 +21,10 @@
         layout: Layout,
         govukButton: GovukButton,
         h1: h1,
-        p: p,
-        appConfig: AppConfig
+        p: p
 )
 
-@()(implicit request: Request[?], messages: Messages)
+@()(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @layout(
     pageTitle = messages("not-authorised.header"),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClient.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClient.scala.html
@@ -1,0 +1,44 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        h1: h1,
+        p: p,
+        appConfig: AppConfig
+)
+
+@()(implicit request: Request[?], messages: Messages)
+
+@layout(
+    pageTitle = messages("not-authorised.header"),
+    serviceName = Some(messages("service.name.clients"))
+) {
+
+    @h1(messages("not-authorised.header"))
+    @p() { @messages("not-authorised.description.p1") }
+    @p() { @messages("not-authorised.description.p2") }
+
+    @govukButton(Button(
+        content = Text(messages("common.sign-out")),
+        href = Some(routes.SignOutController.signOut.url)
+    ))
+
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/components/p.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/components/p.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(classes: String = "govuk-body", id: Option[String] = None)(content: Html)
+
+<p class="@classes" @if(id.nonEmpty){id="@id"}>@content</p>

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
+import play.sbt.routes.RoutesKeys
 import uk.gov.hmrc.DefaultBuildSettings
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "3.4.2"
+ThisBuild / scalaVersion := "3.5.1"
 
 lazy val microservice = Project("agent-client-relationships-frontend", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
@@ -15,6 +16,17 @@ lazy val microservice = Project("agent-client-relationships-frontend", file(".")
   )
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(CodeCoverageSettings.settings)
+  .settings(
+    RoutesKeys.routesImport += "uk.gov.hmrc.play.bootstrap.binders.RedirectUrl"
+  )
+  .settings(
+    TwirlKeys.templateImports ++= Seq(
+      "uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.Layout",
+      "uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components._",
+      "uk.gov.hmrc.govukfrontend.views.html.components._",
+      "uk.gov.hmrc.hmrcfrontend.views.html.components._",
+    )
+  )
 
 lazy val it = project
   .enablePlugins(PlayScala)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -27,3 +27,12 @@ GET         /invitations/created                                                
 # Sign out/Timed out ---------------------------------------------------------------------------------------------------------
 GET         /timed-out                                                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TimedOutController.timedOut
 GET         /sign-out                                                                   uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.SignOutController.signOut
+
+# Auth/IV --------------------------------------------------------------------------------------------------------------------
+GET         /cannot-view-request                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.cannotViewRequest
+GET         /cannot-confirm-identity                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.cannotConfirmIdentity(journeyId: Option[String] ?= None, continueUrl: Option[RedirectUrl] ?= None)
+GET         /iv-timed-out                                                               uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.handleIVTimeout(continueUrl: Option[RedirectUrl] ?= None)
+GET         /iv-locked-out                                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.lockedOut
+
+GET         /auth-agent                                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TestAuthController.agent
+GET         /auth-client                                                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TestAuthController.client

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -31,8 +31,8 @@ GET         /sign-out                                                           
 # Auth/IV --------------------------------------------------------------------------------------------------------------------
 GET         /cannot-view-request                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.cannotViewRequest
 GET         /cannot-confirm-identity                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.cannotConfirmIdentity(journeyId: Option[String] ?= None, continueUrl: Option[RedirectUrl] ?= None)
-GET         /iv-timed-out                                                               uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.handleIVTimeout(continueUrl: Option[RedirectUrl] ?= None)
-GET         /iv-locked-out                                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.lockedOut
+GET         /iv-timed-out                                                               uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.ivTimedOut(continueUrl: Option[RedirectUrl] ?= None)
+GET         /iv-locked-out                                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.ivLockedOut
 
 GET         /auth-agent                                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TestAuthController.agent
 GET         /auth-client                                                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TestAuthController.client

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -30,13 +30,33 @@ play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
 microservice {
-  services {
-    contact-frontend {
-      protocol = http
-      host = localhost
-      port = 9250
+    services {
+        auth {
+            host = localhost
+            port = 8500
+        }
+        contact-frontend {
+            protocol = http
+            host = localhost
+            port = 9250
+        }
+        agent-client-relationships-frontend {
+            external-url = "http://localhost:9448"
+        }
+        agent-services-account-frontend {
+            external-url = "http://localhost:9401"
+        }
+        agent-subscription-frontend {
+            subscription-url = "http://localhost:9437/agent-subscription/start"
+        }
+        identity-verification-uplift {
+            url = "http://localhost:9948/iv-stub/uplift"
+        }
+        identity-verification-frontend {
+            host = localhost
+            port = 9938
+        }
     }
-  }
 }
 
 play.i18n.langCookieHttpOnly: "true"
@@ -109,3 +129,11 @@ cache.suspensionDetails.duration = 15 minutes
 contact-frontend.serviceId = "AgentClientRelationshipsFrontend"
 
 agent-services-account-frontend-home-url = "http://localhost:9401/agent-services-account/home"
+
+allowed-redirect-hosts = [
+    "localhost",
+    "www.gov.uk",
+    "www.qa.tax.service.gov.uk",
+    "www.staging.tax.service.gov.uk",
+    "www.tax.service.gov.uk"
+]

--- a/conf/messages
+++ b/conf/messages
@@ -2,13 +2,65 @@
 # Common
 # -------------------------------------------------------------------------------------------
 service.name.agents.auth=Ask a client to authorise you
+service.name.agents.de-auth=Cancel a client’s authorisation
+service.name.clients=Appoint someone to deal with HMRC for you
 
 error.prefix=Error:' '
 error.heading=There is a problem
 
 continue.button=Continue
+try-again.button=Try again
 button.copy=Copy link to clipboard
 button.copied=Link copied
+
+# -------------------------------------------------------------------------------------------
+# Timeout/Auth/IV error pages
+# -------------------------------------------------------------------------------------------
+
+# Cannot confirm identity
+cannot-confirm-identity.header=We could not confirm your identity
+cannot-confirm-identity.p1=The information you have entered does not match our records.
+cannot-confirm-identity.p2=If you need help with confirming your identity, use the ‘Is this page not working properly’ link.
+
+# Locked-out
+locked-out.header=We could not confirm your identity
+locked-out.p1=You have entered information that does not match our records too many times.
+locked-out.p2=For security reasons, you must wait 24 hours and then sign in to try again.
+locked-out.p3=If you need help with confirming your identity, use the ‘Is this page not working properly’ link.
+
+# Timed out
+timed-out.header=You have been signed out
+timed-out.p1=You have not done anything for {0}, so we have signed you out to keep your account secure.
+timed-out.p2.link=Sign in again
+timed-out.p2.end=to use this service.
+timed-out.button=Start again
+timed-out.minutes=minutes
+timed-out.seconds=seconds
+
+# Technical issues
+technical-issues.header=Sorry, there is a problem with the service
+technical-issues.p1=Try again later.
+technical-issues.p2=We may not have saved your answers. When the service is available, you may have to start again.
+technical-issues.sa-url=https://www.gov.uk/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk
+technical-issues.vat-url=https://www.gov.uk/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk
+technical-issues.vat.link=Call the VAT online services helpline
+technical-issues.vat.end=if you need help with VAT.
+technical-issues.it.link=Call the HMRC Self Assessment online services helpline
+technical-issues.it.end=if you need help with Making Tax Digital for Income Tax.
+
+#Not Authorised
+not-authorised.header=You cannot access this page
+not-authorised.description.p1=This page can only be accessed by your client.
+not-authorised.description.p2=Ask your client to go to the link that you tried to access, so they can accept your authorisation request.
+
+#Error Cannot View Request
+error.cannot-view-request.header=You cannot view this authorisation request
+error.cannot-view-request.p1=You have signed in using an agent user ID.
+error.cannot-view-request.p2=If you are the agent, ask your client to respond to the authorisation request link.
+error.cannot-view-request.p3=If you are not an agent, sign in with the Government Gateway user ID that you use for your {0}.
+error.cannot-view-request.button=Sign in
+error.cannot-view-request.client-type.business=business tax affairs
+error.cannot-view-request.client-type.personal=personal tax affairs
 
 # -------------------------------------------------------------------------------------------
 # Select Client Type

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -2,12 +2,63 @@
 # Common
 # -------------------------------------------------------------------------------------------
 service.name.agents.auth=Gofyn i gleient eich awdurdodi
+service.name.agents.de-auth=Canslo awdurdodiad cleient
+service.name.clients=Penodi rhywun i ddelio â CThEM ar eich rhan
 
 error.prefix=Gwall:' '
 error.heading=Mae problem wedi codi
 
 continue.button=Yn eich blaen
+try-again.button=Rhoi cynnig arall arni
 
+# -------------------------------------------------------------------------------------------
+# Timeout/Auth/IV error pages
+# -------------------------------------------------------------------------------------------
+
+# Cannot confirm identity
+cannot-confirm-identity.header=Nid oeddem yn gallu cadarnhau pwy ydych
+cannot-confirm-identity.p1=Nid yw’r wybodaeth yr ydych wedi’i nodi yn cyd-fynd â’n cofnodion.
+cannot-confirm-identity.p2=Os oes angen help arnoch i gadarnhau pwy ydych, defnyddiwch y cysylltiad ‘A yw’r dudalen hon yn gweithio’n iawn’.
+
+# Locked-out
+locked-out.header=Nid oeddem yn gallu cadarnhau pwy ydych
+locked-out.p1=Rydych wedi nodi gwybodaeth nad yw’n cyd-fynd â’n cofnodion gormod o weithiau.
+locked-out.p2=Am resymau diogelwch, mae’n rhaid i chi aros 24 awr ac yna mewngofnodi i roi cynnig arall arni.
+locked-out.p3=Os oes angen help arnoch i gadarnhau pwy ydych, defnyddiwch y cysylltiad ‘A yw’r dudalen hon yn gweithio’n iawn’.
+
+#Timed out
+timed-out.header=Rydych wedi cael eich allgofnodi
+timed-out.p1=Nid ydych wedi gwneud dim byd ers {0}, felly rydym wedi’ch allgofnodi er mwyn cadw’ch cyfrif yn ddiogel.
+timed-out.p2.link=Mewngofnodwch eto
+timed-out.p2.end=i ddefnyddio’r gwasanaeth hwn.
+timed-out.button=Dechrau eto
+timed-out.minutes=munud
+timed-out.seconds=eiliad
+
+# Technical issues
+technical-issues.header=Mae’n ddrwg gennym, mae problem gyda’r gwasanaeth
+technical-issues.p1=Rhowch gynnig arall arni yn nes ymlaen.
+technical-issues.p2=Efallai nad ydym wedi cadw’ch atebion. Pan fydd y gwasanaeth ar gael, efallai y bydd yn rhaid i chi ddechrau eto.
+technical-issues.sa-url=https://www.gov.uk/government/organisations/hm-revenue-customs/contact/welsh-language-helplines
+technical-issues.vat-url= https://www.gov.uk/government/organisations/hm-revenue-customs/contact/vat-customs-and-excise-and-duties-enquiries-for-welsh-speaking-customers
+technical-issues.vat.link=Ffoniwch linell Ymholiadau TAW, Tollau ac Ecséis CThEM
+technical-issues.vat.end=os oes angen help arnoch gyda’r cynllun TAW.
+technical-issues.it.link=Ffoniwch Wasanaeth Cwsmeriaid Cymraeg CThEM
+technical-issues.it.end=os oes angen help arnoch gyda’r cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm.
+
+#Not Authorised
+not-authorised.header=Nid oes gennych fynediad at y dudalen hon
+not-authorised.description.p1=Dim ond eich cleient all fynd at y dudalen hon.
+not-authorised.description.p2=Gofynnwch i’ch cleient ddilyn y cysylltiad yr oeddech yn ceisio’i ddefnyddio er mwyn iddo allu derbyn eich cais am awdurdodiad.
+
+#Error Cannot View Request
+error.cannot-view-request.header=Ni allwch fwrw golwg dros y cais am awdurdodiad hwn
+error.cannot-view-request.p1=Rydych wedi mewngofnodi gan ddefnyddio Dynodydd Defnyddiwr (ID) asiant.
+error.cannot-view-request.p2=Os mai chi yw’r asiant, gofynnwch i’ch cleient ddilyn y cysylltiad er mwyn ymateb i’r cais am awdurdodiad.
+error.cannot-view-request.p3=Os nad ydych yn asiant, mewngofnodwch gyda’r Dynodydd Defnyddiwr (ID) ar gyfer Porth y Llywodraeth rydych yn ei ddefnyddio ar gyfer eich {0}.
+error.cannot-view-request.button=Mewngofnodi
+error.cannot-view-request.client-type.business=materion treth busnes
+error.cannot-view-request.client-type.personal=materion treth personol
 
 # -------------------------------------------------------------------------------------------
 # Select Client Type

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActionsISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActionsISpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.agentclientrelationshipsfrontend.auth
 
 class AuthActionsISpec {

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActionsISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/auth/AuthActionsISpec.scala
@@ -1,0 +1,5 @@
+package uk.gov.hmrc.agentclientrelationshipsfrontend.auth
+
+class AuthActionsISpec {
+
+}

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/IdentityVerificationConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/IdentityVerificationConnectorISpec.scala
@@ -1,0 +1,34 @@
+package uk.gov.hmrc.agentclientrelationshipsfrontend.connectors
+
+import play.api.libs.json.Json
+import play.api.test.Helpers.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.ComponentSpecHelper
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
+import uk.gov.hmrc.http.HeaderCarrier
+
+class IdentityVerificationConnectorISpec extends ComponentSpecHelper {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  val connector: IdentityVerificationConnector = app.injector.instanceOf[IdentityVerificationConnector]
+
+  val testJourneyId = "123"
+
+  def ivUrl(id: String) = s"/mdtp/journey/journeyId/$id"
+
+  "getIVResult" should {
+    Seq(Success, Incomplete, PreconditionFailed, LockedOut, InsufficientEvidence, FailedMatching,
+      TechnicalIssue, UserAborted, TimedOut, FailedIv, FailedDirectorCheck).foreach { ivResult =>
+      s"return the $ivResult reason when the journey id is valid" in {
+        stubGet(ivUrl(testJourneyId), OK, Json.obj("result" -> Json.toJson[IvResult](ivResult)).toString)
+        val result = connector.getIVResult(testJourneyId)
+        await(result) shouldBe Some(ivResult)
+      }
+    }
+    "return nothing when the journey id is not valid" in {
+      stubGet(ivUrl(testJourneyId), NOT_FOUND, "")
+      val result = connector.getIVResult(testJourneyId)
+      await(result) shouldBe None
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationControllerISpec.scala
@@ -1,0 +1,5 @@
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers
+
+class AuthorisationControllerISpec {
+
+}

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationControllerISpec.scala
@@ -1,5 +1,117 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers
 
-class AuthorisationControllerISpec {
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.ComponentSpecHelper
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.UserTimedOut
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.auth.{CannotConfirmIdentity, IvLockedOut, IvTechDifficulties}
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 
+class AuthorisationControllerISpec extends ComponentSpecHelper {
+
+  val controller: AuthorisationController = app.injector.instanceOf[AuthorisationController]
+
+  def fakeRequest(method: String = GET, uri: String = "/"): FakeRequest[AnyContentAsEmpty.type] =
+    FakeRequest(method, uri)
+
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
+  implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(request)
+
+  val testUrl = "/url"
+  val testJourneyId = "123"
+
+  def ivUrl(id: String) = s"/mdtp/journey/journeyId/$id"
+
+  "GET /cannot-view-request" should {
+    "return NOT_IMPLEMENTED" in {
+      //TODO add the checks for the two possible views that can be returned once they're implemented
+      val request = controller.cannotViewRequest(fakeRequest())
+
+      status(request) shouldBe NOT_IMPLEMENTED
+    }
+  }
+
+  "GET /cannot-confirm-identity" should {
+    "return FORBIDDEN with the CannotConfirmIdentity view when there's no journeyId" in {
+      val request = controller.cannotConfirmIdentity(None, Some(RedirectUrl(testUrl)))(fakeRequest())
+      lazy val view = app.injector.instanceOf[CannotConfirmIdentity]
+
+      status(request) shouldBe FORBIDDEN
+      contentAsString(request) shouldBe view(Some(testUrl)).body
+    }
+    "return FORBIDDEN with the IvTechDifficulties view when the journey status is TechnicalIssue" in {
+      stubGet(ivUrl(testJourneyId), OK, Json.obj("result" -> "TechnicalIssue").toString)
+
+      val request = controller.cannotConfirmIdentity(Some(testJourneyId), Some(RedirectUrl(testUrl)))(fakeRequest())
+      lazy val view = app.injector.instanceOf[IvTechDifficulties]
+
+      status(request) shouldBe FORBIDDEN
+      contentAsString(request) shouldBe view().body
+    }
+    "redirect to /iv-timed-out when the journey status is TimedOut" in {
+      stubGet(ivUrl(testJourneyId), OK, Json.obj("result" -> "Timeout").toString)
+
+      val request = controller.cannotConfirmIdentity(Some(testJourneyId), Some(RedirectUrl(testUrl)))(fakeRequest())
+
+      status(request) shouldBe SEE_OTHER
+      redirectLocation(request) shouldBe Some(routes.AuthorisationController.ivTimedOut(Some(RedirectUrl(testUrl))).url)
+    }
+    "redirect to /iv-locked-out when the journey status is LockedOut" in {
+      stubGet(ivUrl(testJourneyId), OK, Json.obj("result" -> "LockedOut").toString)
+
+      val request = controller.cannotConfirmIdentity(Some(testJourneyId), Some(RedirectUrl(testUrl)))(fakeRequest())
+
+      status(request) shouldBe SEE_OTHER
+      redirectLocation(request) shouldBe Some(routes.AuthorisationController.ivLockedOut.url)
+    }
+    "return FORBIDDEN with the CannotConfirmIdentity view for any other journey status" in {
+      stubGet(ivUrl(testJourneyId), OK, Json.obj("result" -> "InsufficientEvidence").toString)
+
+      val request = controller.cannotConfirmIdentity(Some(testJourneyId), Some(RedirectUrl(testUrl)))(fakeRequest())
+      lazy val view = app.injector.instanceOf[CannotConfirmIdentity]
+
+      status(request) shouldBe FORBIDDEN
+      contentAsString(request) shouldBe view(Some(testUrl)).body
+    }
+  }
+
+  "GET /iv-timed-out" should {
+    "return FORBIDDEN with the TimedOut view" in {
+      val request = controller.ivTimedOut(Some(RedirectUrl(testUrl)))(fakeRequest())
+      lazy val view = app.injector.instanceOf[UserTimedOut]
+
+      status(request) shouldBe FORBIDDEN
+      contentAsString(request) shouldBe view(Some(testUrl), isAgent = false).body
+    }
+  }
+
+  "GET /iv-locked-out" should {
+    "return FORBIDDEN with the IvLockedOut view" in {
+      val request = controller.ivLockedOut()(fakeRequest())
+      lazy val view = app.injector.instanceOf[IvLockedOut]
+
+      status(request) shouldBe FORBIDDEN
+      contentAsString(request) shouldBe view().body
+    }
+  }
 }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/messages/MessagesSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/messages/MessagesSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.messages
+
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
+import scala.io.Source
+
+class MessagesSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar {
+
+  private def getMessageKeys(fileName: String) = {
+    Source.fromResource(fileName)
+      .getLines()
+      .filter(!_.startsWith("#"))
+      .filter(_.nonEmpty)
+      .map(_.split('=').head)
+      .map(_.trim)
+      .toList
+  }
+
+  val english: List[String] = getMessageKeys("messages")
+  val welsh: List[String] = getMessageKeys("messages.cy")
+
+  "The English messages file" ignore {
+    "have a corresponding Welsh translation" in {
+      val missingKeys: List[String] = english.filterNot(welsh.contains)
+
+      if (missingKeys.nonEmpty) fail(s"Missing keys in Welsh translation: ${missingKeys.mkString("\n", "\n", "\n")}")
+    }
+
+    "have no duplicates" in {
+      val duplicateKeys: List[String] = english.diff(english.distinct).distinct
+
+      if (duplicateKeys.nonEmpty) fail(s"Duplicate keys in English translation: ${duplicateKeys.mkString("\n", "\n", "\n")}")
+    }
+  }
+
+  "The Welsh messages file" ignore {
+    "have a corresponding English translation" in {
+      val missingKeys: List[String] = welsh.filterNot(english.contains)
+
+      if (missingKeys.nonEmpty) fail(s"Missing keys in English translation: ${missingKeys.mkString("\n", "\n", "\n")}")
+    }
+
+
+    "have no duplicates" in {
+      val duplicateKeys: List[String] = welsh.diff(welsh.distinct).distinct
+
+      if (duplicateKeys.nonEmpty) fail(s"Duplicate keys in Welsh translation: ${duplicateKeys.mkString("\n", "\n", "\n")}")
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/Selectors.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/Selectors.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.support
+
+trait Selectors {
+  // Outside main-content
+  val languageSwitcher = ".hmrc-language-select"
+  val main = "#main-content"
+
+  // Inside main-content
+  val h1 = "h1"
+  val h2 = "h2"
+  val h3 = "h3"
+  val p = "p"
+  val visuallyHidden = ".govuk-visually-hidden"
+  val link = ".govuk-link"
+  val list = ".govuk-list"
+  val inset = ".govuk-inset-text"
+  val hint = ".govuk-hint"
+  val captionM = ".govuk-caption-m"
+  val captionL = ".govuk-caption-l"
+  val captionXL = ".govuk-caption-xl"
+  val button = ".govuk-button"
+
+  val table = ".govuk-table"
+  val tableCaption = ".govuk-table__caption"
+  val tableHead = ".govuk-table__head"
+  val tableBody = ".govuk-table__body"
+  val tableRow = ".govuk-table__row"
+  val tableRowHeader = ".govuk-table__header"
+  val tableRowCell = ".govuk-table__cell"
+
+  val summaryList = ".govuk-summary-list"
+  val summaryListRow = ".govuk-summary-list__row"
+  val summaryListRowKey = ".govuk-summary-list__key"
+  val summaryListRowValue = ".govuk-summary-list__value"
+  val summaryListRowAction = ".govuk-summary-list__action"
+
+  val notificationBannerTitle = ".govuk-notification-banner__title"
+  val notificationBannerContent = ".govuk-notification-banner__content"
+
+  val detailsSummary = ".govuk-details__summary-text"
+  val detailsContent = ".govuk-details__text"
+
+  val warning = ".govuk-warning-text"
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/ViewSpecHelper.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/ViewSpecHelper.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.support
+
+import org.jsoup.nodes.Element
+import org.jsoup.select.Elements
+
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+import scala.language.implicitConversions
+
+trait ViewSpecHelper extends Selectors {
+  extension (elements: Elements)
+    def toList: List[Element] = elements.iterator.asScala.toList
+    def headOption: Option[Element] = toList.headOption
+
+
+  case class TestLink(text: String, href: String)
+
+  private val elementToLink: Element => TestLink = element => TestLink(element.text(), element.attr("href"))
+
+  extension (el: Element)
+    def hasLanguageSwitch: Boolean = el.select(languageSwitcher).headOption.nonEmpty
+    def mainContent: Element = el.select(main).headOption.get
+
+    //  Will find the element by id or index and return the element as option
+    //  Index lookup is 1-indexed, if you want the first element then pass in 1
+    //  Can be chained to extract elements inside other elements without keeping track of indeces in the whole view like:
+    //    val para = extractByIndex(para, 1)
+    //    para.extractText(visuallyHidden, 1)
+    //    para.extractLink(1)
+    def extractByIndex(selector: String, index: Int): Option[Element] = el.select(selector).toList.lift(index - 1)
+    def extractById(selector: String, id: String): Option[Element] = el.select(selector).select(s"#$id").headOption
+
+    def extractText(selector: String, index: Int): Option[String] = extractByIndex(selector, index).map(_.text())
+    def extractText(selector: String, id: String): Option[String] = extractById(selector, id).map(_.text())
+
+    def extractList(index: Int): List[String] = el.select(list).toList.lift(index).map(_.getElementsByTag("li").toList.map(_.text())).getOrElse(Nil)
+
+    def extractLink(index: Int): Option[TestLink] = extractByIndex(link, index).map(elementToLink)
+    def extractLink(id: String): Option[TestLink] = extractById(link, id).map(elementToLink)
+
+    def extractLinkButton(index: Int): Option[TestLink] = extractByIndex(button, index).map(elementToLink)
+    def extractLinkButton(id: String): Option[TestLink] = extractById(button, id).map(elementToLink)
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/ViewSpecSupport.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/ViewSpecSupport.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.support
+
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+
+trait ViewSpecSupport extends AnyWordSpecLike with Matchers with OptionValues with BeforeAndAfterEach with GuiceOneAppPerSuite with ViewSpecHelper {
+
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(request)
+  // Override appConfig with a mock if need to test with different config values
+  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/util/UrlHelperSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/util/UrlHelperSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.util
+
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.UrlHelper
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
+
+class UrlHelperSpec extends AnyWordSpecLike with Matchers with OptionValues with BeforeAndAfterEach {
+
+  implicit val appConfig: AppConfig = mock[AppConfig]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(appConfig)
+  }
+
+  val testUrl = "/url"
+  val key1 = "key1"
+  val param1 = "param1"
+  val key2 = "key2"
+  val param2 = "param2"
+  val keyUrl = "keyUrl"
+
+  "addParamsToUrl" should {
+    "add the list of parameters to a url without any" in {
+      val url = UrlHelper.addParamsToUrl(testUrl, (key1, Some(param1)), (key2, Some(param2)))
+
+      url shouldBe "/url?key1=param1&key2=param2"
+    }
+    "add the list of parameters to a url without some appended already" in {
+      val urlWithParams = UrlHelper.addParamsToUrl(testUrl, (key1, Some(param1)))
+      val url = UrlHelper.addParamsToUrl(urlWithParams, (key2, Some(param2)))
+
+      url shouldBe "/url?key1=param1&key2=param2"
+    }
+    "encode parameters it is trying to append" in {
+      val paramUrl = UrlHelper.addParamsToUrl(testUrl, (key1, Some(param1)), (key2, Some(param2)))
+      val url = UrlHelper.addParamsToUrl(testUrl, (keyUrl, Some(paramUrl)))
+
+      url shouldBe "/url?keyUrl=%2Furl%3Fkey1%3Dparam1%26key2%3Dparam2"
+    }
+  }
+
+  "validateRedirectUrl" should {
+    "validate a RedirectUrl if it is relative" in {
+      val testUrl = "/url"
+
+      UrlHelper.validateRedirectUrl(RedirectUrl(testUrl)) shouldBe testUrl
+    }
+    "validate a RedirectUrl with a valid host" in {
+      when(appConfig.allowedRedirectHosts).thenReturn(Set("localhost"))
+      val testUrl = "http://localhost:9000/url"
+
+      UrlHelper.validateRedirectUrl(RedirectUrl(testUrl)) shouldBe testUrl
+    }
+    "fail on a RedirectUrl with an invalid host" in {
+      when(appConfig.allowedRedirectHosts).thenReturn(Set("localhost"))
+      val testUrl = "http://invalidhost.com/url"
+
+      intercept[IllegalArgumentException](UrlHelper.validateRedirectUrl(RedirectUrl(testUrl))).getMessage shouldBe
+        "Provided URL [http://invalidhost.com/url] doesn't comply with redirect policy"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOutSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOutSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.UserTimedOut
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.auth.IvTechDifficulties
+
+class UserTimedOutSpec extends ViewSpecSupport {
+
+  val viewTemplate: UserTimedOut = app.injector.instanceOf[UserTimedOut]
+
+  val testUrl = "/url"
+
+  object ExpectedClient {
+    val title = "You have been signed out - Appoint someone to deal with HMRC for you - GOV.UK"
+    val heading = "You have been signed out"
+    val para1 = "You have not done anything for 15 minutes, so we have signed you out to keep your account secure."
+    val linkText1 = "Start again"
+  }
+
+  object ExpectedAgent {
+    val title = "You have been signed out - Ask a client to authorise you - GOV.UK"
+    val heading = "You have been signed out"
+    val para1 = "You have not done anything for 15 minutes, so we have signed you out to keep your account secure."
+    val linkText1 = "Sign in again"
+    val para2 = s"$linkText1 to use this service."
+  }
+
+  "UserTimedOut view" when {
+    "viewed as a client" should {
+      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), false)
+      val doc: Document = Jsoup.parse(view.body)
+      "have the right title" in {
+        doc.title() shouldBe ExpectedClient.title
+      }
+      "have a language switcher" in {
+        doc.hasLanguageSwitch shouldBe true
+      }
+      "have the right heading" in {
+        doc.mainContent.extractText(h1, 1).value shouldBe ExpectedClient.heading
+      }
+      "have the right paras" in {
+        doc.mainContent.extractText(p, 1).value shouldBe ExpectedClient.para1
+      }
+      "have a link button" in {
+        doc.mainContent.extractLinkButton(1).value shouldBe TestLink(ExpectedClient.linkText1, testUrl)
+      }
+    }
+    "viewed as an agent" should {
+      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), true)
+      val doc: Document = Jsoup.parse(view.body)
+      "have the right title" in {
+        doc.title() shouldBe ExpectedAgent.title
+      }
+      "have a language switcher" in {
+        doc.hasLanguageSwitch shouldBe true
+      }
+      "have the right heading" in {
+        doc.mainContent.extractText(h1, 1).value shouldBe ExpectedAgent.heading
+      }
+      "have the right paras" in {
+        doc.mainContent.extractText(p, 1).value shouldBe ExpectedAgent.para1
+        doc.mainContent.extractText(p, 2).value shouldBe ExpectedAgent.para2
+      }
+      "have a link" in {
+        doc.mainContent.extractLink(1).value shouldBe TestLink(ExpectedAgent.linkText1, testUrl)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentitySpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentitySpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.auth
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.auth.CannotConfirmIdentity
+
+class CannotConfirmIdentitySpec extends ViewSpecSupport {
+
+  val viewTemplate: CannotConfirmIdentity = app.injector.instanceOf[CannotConfirmIdentity]
+
+  val testUrl = "/url"
+
+  object Expected {
+    val title = "We could not confirm your identity - Appoint someone to deal with HMRC for you - GOV.UK"
+    val heading = "We could not confirm your identity"
+    val para1 = "The information you have entered does not match our records."
+    val para2 = "If you need help with confirming your identity, use the ‘Is this page not working properly’ link."
+    val linkText = "Try again"
+  }
+
+  "CannotConfirmIdentity view" when {
+    "generated with a url" should {
+      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl))
+      val doc: Document = Jsoup.parse(view.body)
+      "have the right title" in {
+        doc.title() shouldBe Expected.title
+      }
+      "have a language switcher" in {
+        doc.hasLanguageSwitch shouldBe true
+      }
+      "have the right heading" in {
+        doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+      }
+      "have the right paras" in {
+        doc.mainContent.extractText(p, 1).value shouldBe Expected.para1
+        doc.mainContent.extractText(p, 2).value shouldBe Expected.para2
+      }
+      "have a link button" in {
+        doc.mainContent.extractLinkButton(1).value shouldBe TestLink(Expected.linkText, testUrl)
+      }
+    }
+    "generated without a url" should {
+      val view: HtmlFormat.Appendable = viewTemplate(None)
+      val doc: Document = Jsoup.parse(view.body)
+      "not have a continue link button" in {
+        doc.mainContent.extractLinkButton(1) shouldBe None
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOutSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOutSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.auth
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.auth.IvLockedOut
+
+class IvLockedOutSpec extends ViewSpecSupport {
+
+  val viewTemplate: IvLockedOut = app.injector.instanceOf[IvLockedOut]
+
+  object Expected {
+    val title = "We could not confirm your identity - Appoint someone to deal with HMRC for you - GOV.UK"
+    val heading = "We could not confirm your identity"
+    val para1 = "You have entered information that does not match our records too many times."
+    val para2 = "For security reasons, you must wait 24 hours and then sign in to try again."
+    val para3 = "If you need help with confirming your identity, use the ‘Is this page not working properly’ link."
+  }
+
+  "IvLockedOut view" should {
+    val view: HtmlFormat.Appendable = viewTemplate()
+    val doc: Document = Jsoup.parse(view.body)
+    "have the right title" in {
+      doc.title() shouldBe Expected.title
+    }
+    "have a language switcher" in {
+      doc.hasLanguageSwitch shouldBe true
+    }
+    "have the right heading" in {
+      doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+    }
+    "have the right paras" in {
+      doc.mainContent.extractText(p, 1).value shouldBe Expected.para1
+      doc.mainContent.extractText(p, 2).value shouldBe Expected.para2
+      doc.mainContent.extractText(p, 3).value shouldBe Expected.para3
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficultiesSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficultiesSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.auth
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.auth.{IvLockedOut, IvTechDifficulties}
+
+class IvTechDifficultiesSpec extends ViewSpecSupport {
+
+  val viewTemplate: IvTechDifficulties = app.injector.instanceOf[IvTechDifficulties]
+
+  object Expected {
+    val title = "Sorry, there is a problem with the service - Appoint someone to deal with HMRC for you - GOV.UK"
+    val heading = "Sorry, there is a problem with the service"
+    val para1 = "Try again later."
+    val para2 = "We may not have saved your answers. When the service is available, you may have to start again."
+    val linkText1 = "Call the VAT online services helpline"
+    val linkText2 = "Call the HMRC Self Assessment online services helpline"
+    val linkUrl1 = "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk"
+    val linkUrl2 = "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk"
+    val para3 = s"$linkText1 if you need help with VAT."
+    val para4 = s"$linkText2 if you need help with Making Tax Digital for Income Tax."
+  }
+
+  "IvTechDifficulties view" should {
+    val view: HtmlFormat.Appendable = viewTemplate()
+    val doc: Document = Jsoup.parse(view.body)
+    "have the right title" in {
+      doc.title() shouldBe Expected.title
+    }
+    "have a language switcher" in {
+      doc.hasLanguageSwitch shouldBe true
+    }
+    "have the right heading" in {
+      doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+    }
+    "have the right paras" in {
+      doc.mainContent.extractText(p, 1).value shouldBe Expected.para1
+      doc.mainContent.extractText(p, 2).value shouldBe Expected.para2
+      doc.mainContent.extractText(p, 3).value shouldBe Expected.para3
+      doc.mainContent.extractText(p, 4).value shouldBe Expected.para4
+    }
+    "have the right links" in {
+      doc.mainContent.extractLink(1).value shouldBe TestLink(Expected.linkText1, Expected.linkUrl1)
+      doc.mainContent.extractLink(2).value shouldBe TestLink(Expected.linkText2, Expected.linkUrl2)
+    }
+  }
+}


### PR DESCRIPTION
Currently missing error handling for an agent viewing a client page because that requires knowledge of clientType which is not set up in the service yet.

Specs/ISpecs still in development