### PR TITLE
APB-8887 Add date partial, refactor to date form helper

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/DateFormFieldHelper.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/DateFormFieldHelper.scala
@@ -16,63 +16,21 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers
 
-import play.api.data.Forms.{text, tuple}
+import play.api.data.Forms.of
 import play.api.data.Mapping
-import play.api.data.validation.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.*
 
 import java.time.LocalDate
-import java.time.format.{DateTimeFormatter, ResolverStyle}
+import scala.util.{Failure, Success, Try}
 
-object DateFormFieldHelper extends FormFieldHelper {
-
-  private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-M-d").withResolverStyle(ResolverStyle.STRICT)
-  
-  private def parseDate(date: String): Boolean =
-    try {
-      LocalDate.parse(date, dateFormatter)
-      true
-    } catch {
-      case _: Throwable => false
-    }
+object DateFormFieldHelper {
 
   def dateFieldMapping(formMessageKey: String): Mapping[String] = {
-    tuple(
-      Year -> text,
-      Month -> text,
-      Day -> text
-    ).verifying(validateDate(formMessageKey))
-      .transform[String](
-        { case (y, m, d) =>
-          if (y.isEmpty || m.isEmpty || d.isEmpty) ""
-          else LocalDate.of(y.toInt, m.toInt, d.toInt).format(dateFormatter)
-        },
-        date =>
-          try {
-            val l = LocalDate.parse(date)
-            (l.getYear.toString, l.getMonthValue.toString, l.getDayOfMonth.toString)
-          } catch {
-            case e: Exception => throw new IllegalArgumentException(s"unexpected date input pattern $e")
-          }
-      )
-  }
-
-  private def validateDate(formMessageKey: String): Constraint[(String, String, String)] = {
-    Constraint[(String, String, String)] { (s: (String, String, String)) =>
-      (s._1.nonEmpty, s._2.nonEmpty, s._3.nonEmpty) match {
-        //   (year, month, day)
-        case (false, false, false) => invalidMandatoryField(formMessageKey, s"$Day-$Month-$Year")
-        case (true, true, false) => invalidMandatoryField(s"$formMessageKey.$Day", Day)
-        case (true, false, true) => invalidMandatoryField(s"$formMessageKey.$Month", Month)
-        case (false, true, true) => invalidMandatoryField(s"$formMessageKey.$Year", Year)
-        case (true, false, false) => invalidMandatoryField(s"$formMessageKey.$Day-$Month", s"$Day-$Month")
-        case (false, true, false) => invalidMandatoryField(s"$formMessageKey.$Day-$Year", s"$Day-$Year")
-        case (false, false, true) => invalidMandatoryField(s"$formMessageKey.$Month-$Year", s"$Month-$Year")
-        case (true, true, true) =>
-          if (parseDate(s"${s._1}-${s._2}-${s._3}")) Valid
-          else invalidInput(formMessageKey, s"$Day-$Month-$Year")
+    of(new LocalDateFormatter(formMessageKey)).transform(
+      date => date.toString,
+      dateString => Try(LocalDate.parse(dateString)) match {
+        case Success(parsedDate) => parsedDate
+        case Failure(_) => throw new IllegalArgumentException("An illegal date was filled to the form without validation")
       }
-    }
+    )
   }
-
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/LocalDateFormatter.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/LocalDateFormatter.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers
+
+import play.api.data.FormError
+import play.api.data.format.Formatter
+
+import java.time.LocalDate
+import scala.util.{Failure, Success, Try}
+
+class LocalDateFormatter(messagePrefix: String) extends Formatter[LocalDate] {
+
+  val invalidKey = s"$messagePrefix.error.invalid"
+  val allRequiredKey = s"$messagePrefix.error.required"
+  val dayRequiredKey = s"$messagePrefix.error.day.required"
+  val monthRequiredKey = s"$messagePrefix.error.month.required"
+  val yearRequiredKey = s"$messagePrefix.error.year.required"
+  val dayMonthRequiredKey = s"$messagePrefix.error.day-month.required"
+  val dayYearRequiredKey = s"$messagePrefix.error.day-year.required"
+  val monthYearRequiredKey = s"$messagePrefix.error.month-year.required"
+
+  def toDate(key: String, day: Int, month: Int, year: Int): Either[Seq[FormError], LocalDate] =
+    Try(LocalDate.of(year, month, day)) match {
+      case Success(date) =>
+        Right(date)
+      case Failure(_) =>
+        Left(Seq(FormError(key, invalidKey)))
+    }
+
+  def validateDayMonthYear(key: String,
+                           day: Option[String],
+                           month: Option[String],
+                           year: Option[String]): Seq[FormError] = {
+
+    def validateDay: Boolean = Try(day.get.toInt).toOption.exists(value => 1 to 31 contains value)
+    def validateMonth: Boolean = Try(month.get.toInt).toOption.exists(value => 1 to 12 contains value)
+    def validateYear: Boolean = Try(year.get.toInt).toOption.exists(value => value > 0)
+
+    (day, month, year) match {
+      case (Some(_), Some(_), Some(_)) =>
+        (validateDay, validateMonth, validateYear) match {
+          case (true, true, true) => Nil
+          case (false, true, true) => Seq(FormError(s"$key.day", invalidKey))
+          case (true, false, true) => Seq(FormError(s"$key.month", invalidKey))
+          case (true, true, false) => Seq(FormError(s"$key.year", invalidKey))
+          case (true, false, false) => Seq(
+            FormError(s"$key.month", invalidKey),
+            FormError(s"$key.year", invalidKey)
+          )
+          case (false, true, false) => Seq(
+            FormError(s"$key.day", invalidKey),
+            FormError(s"$key.year", invalidKey)
+          )
+          case (false, false, true) => Seq(
+            FormError(s"$key.day", invalidKey),
+            FormError(s"$key.month", invalidKey)
+          )
+          case (false, false, false) => Seq(FormError(key, invalidKey))
+        }
+      case (None, Some(_), Some(_)) => Seq(FormError(s"$key.day", dayRequiredKey))
+      case (Some(_), None, Some(_)) => Seq(FormError(s"$key.month", monthRequiredKey))
+      case (Some(_), Some(_), None) => Seq(FormError(s"$key.year", yearRequiredKey))
+      case (Some(_), None, None) => Seq(
+        FormError(s"$key.month", monthYearRequiredKey),
+        FormError(s"$key.year", monthYearRequiredKey)
+      )
+      case (None, Some(_), None) => Seq(
+        FormError(s"$key.day", dayYearRequiredKey),
+        FormError(s"$key.year", dayYearRequiredKey)
+      )
+      case (None, None, Some(_)) => Seq(
+        FormError(s"$key.day", dayMonthRequiredKey),
+        FormError(s"$key.month", dayMonthRequiredKey)
+      )
+      case _ => Seq(FormError(key, allRequiredKey))
+    }
+  }
+
+  override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+    val dayKey: String = s"$key.day"
+    val monthKey: String = s"$key.month"
+    val yearKey: String = s"$key.year"
+
+    val dayValue: Option[String] = data.get(dayKey).filter(_.nonEmpty)
+    val monthValue: Option[String] = data.get(monthKey).filter(_.nonEmpty)
+    val yearValue: Option[String] = data.get(yearKey).filter(_.nonEmpty)
+
+    val errors = validateDayMonthYear(key, dayValue, monthValue, yearValue)
+
+    errors match {
+      case Nil => toDate(key, dayValue.get.toInt, monthValue.get.toInt, yearValue.get.toInt)
+      case _ => Left(errors)
+    }
+  }
+
+  override def unbind(key: String, value: LocalDate): Map[String, String] =
+    Map(
+      s"$key.day" -> value.getDayOfMonth.toString,
+      s"$key.month" -> value.getMonthValue.toString,
+      s"$key.year" -> value.getYear.toString
+    )
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/Journey.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/Journey.scala
@@ -37,7 +37,7 @@ case class Journey(journeyType: JourneyType,
 
   def getClientDetailsResponse: ClientDetailsResponse = clientDetailsResponse.getOrElse(throw new RuntimeException("client details are not defined"))
 
-  def getKnowFactType: KnownFactType = clientDetailsResponse.flatMap(_.knownFactType)getOrElse(throw new RuntimeException("known fact is not defined"))
+  def getKnownFactType: KnownFactType = clientDetailsResponse.flatMap(_.knownFactType)getOrElse(throw new RuntimeException("known fact is not defined"))
 
   // TODO: Implement this method for real when our clientDetailsResponse contains
   //  everything we need such as existing invitations or authorisations

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/Layout.scala.html
@@ -74,8 +74,14 @@ equal the page heading (H1) content *@
 
 @content = {
     @optionalForm.map { form =>
-        @if(form.hasErrors) {
-            @govukErrorSummary(ErrorSummary().withFormErrorsAsText(form))
+        @form.errors.headOption.map { error =>
+            @govukErrorSummary(ErrorSummary(
+                title = Text(messages("error.heading")),
+                errorList = Seq(ErrorLink(
+                    href = if(error.key == "date") Some("#date.day") else Some(s"#${error.key}"),
+                    content = Text(messages(error.message, error.args: _*))
+                ))
+            ))
         }
     }
     @contentBlock

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPage.scala.html
@@ -22,7 +22,8 @@
 @this(
         layout: Layout,
         countryCodePartial: Country,
-        emailPartial: Email
+        emailPartial: Email,
+        datePartial: Date
 )
 
 @(form: Form[?], inputField: KnownFactsConfiguration)(implicit request: AgentJourneyRequest[?], messages: Messages)
@@ -54,7 +55,7 @@
             case KnownFactType.PostalCode => "postcodeHtmlTemplate(form, inputField, messagePrefix)"
             case KnownFactType.CountryCode => countryCodePartial(form, inputField, messagePrefix)
             case KnownFactType.Email => emailPartial(form, inputField, messagePrefix)
-            case KnownFactType.Date => "dateHtmlTemplate(form, inputField, messagePrefix)"
+            case KnownFactType.Date => datePartial(form, inputField, messagePrefix)
         }
     }
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/Date.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/Date.scala.html
@@ -1,0 +1,39 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyRequest
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits.RichDateInput
+
+@this(govukDateInput: GovukDateInput, submitButton: SubmitButton, formWithCSRF: FormWithCSRF)
+
+@(form: Form[?], inputField: KnownFactsConfiguration, messagePrefix: String)(implicit request: AgentJourneyRequest[?], messages: Messages)
+
+@formWithCSRF(routes.EnterClientFactController.onSubmit(request.journey.journeyType)) {
+    @govukDateInput(DateInput(
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages(s"$messagePrefix.label")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            ))
+        )),
+        hint = Some(Hint(content = Text(messages(s"$messagePrefix.hint"))))
+    ).withDayMonthYearFormField(form("date")))
+
+    @submitButton()
+}

--- a/conf/messages
+++ b/conf/messages
@@ -169,8 +169,26 @@ clientId.PlrId.error.required=Enter your client’s  date of registration to rep
 clientFact.HMRC-MTD-IT.postcode.label=What is your client’s postcode?
 
 clientFact.PERSONAL-INCOME-RECORD.date.label=What is your client’s date of birth?
+clientFact.PERSONAL-INCOME-RECORD.date.hint=For example, 22 7 1981.
+clientFact.PERSONAL-INCOME-RECORD.date.error.required=Enter your client’s date of birth
+clientFact.PERSONAL-INCOME-RECORD.date.error.invalid=Date of birth must be a valid date
+clientFact.PERSONAL-INCOME-RECORD.date.error.day.required=Date of birth must include a day
+clientFact.PERSONAL-INCOME-RECORD.date.error.month.required=Date of birth must include a month
+clientFact.PERSONAL-INCOME-RECORD.date.error.year.required=Date of birth must include a year
+clientFact.PERSONAL-INCOME-RECORD.date.error.day-month.required=Date of birth must include a day and month
+clientFact.PERSONAL-INCOME-RECORD.date.error.day-year.required=Date of birth must include a day and year
+clientFact.PERSONAL-INCOME-RECORD.date.error.month-year.required=Date of birth must include a month and year
 
 clientFact.HMRC-MTD-VAT.date.label=When did the client’s VAT registration start?
+clientFact.HMRC-MTD-VAT.date.hint=The date of registration is on the client’s VAT certificate. For example, 31 8 2015.
+clientFact.HMRC-MTD-VAT.date.error.required=Enter your client’s VAT registration date
+clientFact.HMRC-MTD-VAT.date.error.invalid=Enter a valid VAT registration date
+clientFact.HMRC-MTD-VAT.date.error.day.required=VAT registration date must include a day
+clientFact.HMRC-MTD-VAT.date.error.month.required=VAT registration date must include a month
+clientFact.HMRC-MTD-VAT.date.error.year.required=VAT registration date must include a year
+clientFact.HMRC-MTD-VAT.date.error.day-month.required=VAT registration date must include a day and month
+clientFact.HMRC-MTD-VAT.date.error.day-year.required=VAT registration date must include a day and year
+clientFact.HMRC-MTD-VAT.date.error.month-year.required=VAT registration date must include a month and year
 
 clientFact.HMRC-CGT-PD.postcode.label=What is your client’s postcode?
 
@@ -178,6 +196,15 @@ clientFact.HMRC-CGT-PD.postcode.label=What is your client’s postcode?
 clientFact.HMRC-CGT-PD.countryCode.label=Which country is your client’s contact address in?
 
 clientFact.HMRC-PPT-ORG.date.label=When did your client’s registration start for Plastic Packaging Tax?
+clientFact.HMRC-PPT-ORG.date.hint=For example, 31 8 2022.
+clientFact.HMRC-PPT-ORG.date.error.required=Enter your client’s Plastic Packaging Tax registration date
+clientFact.HMRC-PPT-ORG.date.error.invalid=Enter a valid Plastic Packaging Tax registration date
+clientFact.HMRC-PPT-ORG.date.error.day.required=Plastic Packaging Tax registration date must include a day
+clientFact.HMRC-PPT-ORG.date.error.month.required=Plastic Packaging Tax registration date must include a month
+clientFact.HMRC-PPT-ORG.date.error.year.required=Plastic Packaging Tax registration date must include a year
+clientFact.HMRC-PPT-ORG.date.error.day-month.required=Plastic Packaging Tax registration date must include a day and month
+clientFact.HMRC-PPT-ORG.date.error.day-year.required=Plastic Packaging Tax registration date must include a day and year
+clientFact.HMRC-PPT-ORG.date.error.month-year.required=Plastic Packaging Tax registration date must include a month and year
 
 clientFact.HMRC-CBC-ORG.email.label=What is your client’s Country-by-Country contact email address?
 clientFact.HMRC-CBC-ORG.email.hint=This is the email your client gave to HMRC for Country-by-Country reporting.
@@ -190,6 +217,15 @@ clientFact.HMRC-CBC-NONUK-ORG.email.error.invalid=Enter your client’s email ad
 clientFact.HMRC-CBC-NONUK-ORG.email.error.required=Enter your client’s email address
 
 clientFact.HMRC-PILLAR2-ORG.date.label=What is your client’s registration date for Pillar 2 top-up taxes?
+clientFact.HMRC-PILLAR2-ORG.date.hint=The current filing member can find it on their Pillar 2 top-up taxes homepage. For example, 27 3 2026.
+clientFact.HMRC-PILLAR2-ORG.date.error.required=Enter your client’s date of registration to report Pillar 2 top-up taxes
+clientFact.HMRC-PILLAR2-ORG.date.error.invalid=Enter a valid Pillar 2 top-up taxes registration date
+clientFact.HMRC-PILLAR2-ORG.date.error.day.required=Pillar 2 top-up taxes registration date must include a day
+clientFact.HMRC-PILLAR2-ORG.date.error.month.required=Pillar 2 top-up taxes registration date must include a month
+clientFact.HMRC-PILLAR2-ORG.date.error.year.required=Pillar 2 top-up taxes registration date must include a year
+clientFact.HMRC-PILLAR2-ORG.date.error.day-month.required=Pillar 2 top-up taxes registration date must include a day and month
+clientFact.HMRC-PILLAR2-ORG.date.error.day-year.required=Pillar 2 top-up taxes registration date must include a day and year
+clientFact.HMRC-PILLAR2-ORG.date.error.month-year.required=Pillar 2 top-up taxes registration date must include a month and year
 
 #-------------------------------------------------------------------------------------------
 # Enter Known Facts

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -172,6 +172,54 @@ error.client-details.cgtRef.required=Nodwch gyfeirnod cyfrif Treth Enillion Cyfa
 error.client-details.cgtRef.invalid=Nodwch gyfeirnod cyfrif Treth Enillion Cyfalaf y cleient yn y fformat cywir
 
 
+#-------------------------------------------------------------------------------------------
+# Enter Client Fact
+# -------------------------------------------------------------------------------------------
+
+clientFact.PERSONAL-INCOME-RECORD.date.label=Beth yw dyddiad geni eich cleient?
+clientFact.PERSONAL-INCOME-RECORD.date.hint=Er enghraifft, 22 7 1981.
+clientFact.PERSONAL-INCOME-RECORD.date.error.required=Nodwch ddyddiad geni’ch cleient
+clientFact.PERSONAL-INCOME-RECORD.date.error.invalid=Mae’n rhaid i’r dyddiad geni fod yn ddyddiad dilys
+clientFact.PERSONAL-INCOME-RECORD.date.error.day.required=Mae’n rhaid i’r dyddiad geni gynnwys diwrnod
+clientFact.PERSONAL-INCOME-RECORD.date.error.month.required=Mae’n rhaid i’r dyddiad geni gynnwys mis
+clientFact.PERSONAL-INCOME-RECORD.date.error.year.required=Mae’n rhaid i’r dyddiad geni gynnwys blwyddyn
+clientFact.PERSONAL-INCOME-RECORD.date.error.day-month.required=Mae’n rhaid i’r dyddiad geni gynnwys diwrnod a mis
+clientFact.PERSONAL-INCOME-RECORD.date.error.day-year.required=Mae’n rhaid i’r dyddiad geni gynnwys diwrnod a blwyddyn
+clientFact.PERSONAL-INCOME-RECORD.date.error.month-year.required=Mae’n rhaid i’r dyddiad geni gynnwys mis a blwyddyn
+
+clientFact.HMRC-MTD-VAT.date.label=<translation needed>
+clientFact.HMRC-MTD-VAT.date.hint=<translation needed>
+clientFact.HMRC-MTD-VAT.date.error.required=Nodwch ddyddiad cofrestru TAW eich cleient
+clientFact.HMRC-MTD-VAT.date.error.invalid=Nodwch ddyddiad cofrestru TAW dilys
+clientFact.HMRC-MTD-VAT.date.error.day.required=Mae’n rhaid i’r dyddiad cofrestru TAW gynnwys diwrnod
+clientFact.HMRC-MTD-VAT.date.error.month.required=Mae’n rhaid i’r dyddiad cofrestru TAW gynnwys mis
+clientFact.HMRC-MTD-VAT.date.error.year.required=Mae’n rhaid i’r dyddiad cofrestru TAW gynnwys blwyddyn
+clientFact.HMRC-MTD-VAT.date.error.day-month.required=Mae’n rhaid i’r dyddiad cofrestru TAW gynnwys diwrnod a mis
+clientFact.HMRC-MTD-VAT.date.error.day-year.required=Mae’n rhaid i’r dyddiad cofrestru TAW gynnwys diwrnod a blwyddyn
+clientFact.HMRC-MTD-VAT.date.error.month-year.required=Mae’n rhaid i’r dyddiad cofrestru TAW gynnwys mis a blwyddyn
+
+clientFact.HMRC-PPT-ORG.date.label=<translation needed>
+clientFact.HMRC-PPT-ORG.date.hint=Er enghraifft, 31 8 2022.
+clientFact.HMRC-PPT-ORG.date.error.required=Nodwch ddyddiad cofrestru eich cleient ar gyfer Treth Deunydd Pacio Plastig
+clientFact.HMRC-PPT-ORG.date.error.invalid=Nodwch ddyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig sy’n ddilys
+clientFact.HMRC-PPT-ORG.date.error.day.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig gynnwys diwrnod
+clientFact.HMRC-PPT-ORG.date.error.month.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig gynnwys mis
+clientFact.HMRC-PPT-ORG.date.error.year.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig gynnwys blwyddyn
+clientFact.HMRC-PPT-ORG.date.error.day-month.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig gynnwys diwrnod a mis
+clientFact.HMRC-PPT-ORG.date.error.day-year.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig gynnwys diwrnod a blwyddyn
+clientFact.HMRC-PPT-ORG.date.error.month-year.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer Treth Deunydd Pacio Plastig gynnwys mis a blwyddyn
+
+clientFact.HMRC-PILLAR2-ORG.date.label=<translation needed>
+clientFact.HMRC-PILLAR2-ORG.date.hint=<translation needed>
+clientFact.HMRC-PILLAR2-ORG.date.error.required=Nodwch ddyddiad cofrestru eich cleient ar gyfer rhoi gwybod am drethi atodol Colofn 2
+clientFact.HMRC-PILLAR2-ORG.date.error.invalid=Nodwch ddyddiad cofrestru ar gyfer trethi atodol Colofn 2 eich cleient
+clientFact.HMRC-PILLAR2-ORG.date.error.day.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer trethi atodol Colofn 2 gynnwys diwrnod
+clientFact.HMRC-PILLAR2-ORG.date.error.month.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer trethi atodol Colofn 2 gynnwys mis
+clientFact.HMRC-PILLAR2-ORG.date.error.year.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer trethi atodol Colofn 2 gynnwys blwyddyn
+clientFact.HMRC-PILLAR2-ORG.date.error.day-month.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer trethi atodol Colofn 2 gynnwys diwrnod a mis
+clientFact.HMRC-PILLAR2-ORG.date.error.day-year.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer trethi atodol Colofn 2 gynnwys diwrnod a blwyddyn
+clientFact.HMRC-PILLAR2-ORG.date.error.month-year.required=Mae’n rhaid i’r dyddiad cofrestru ar gyfer trethi atodol Colofn 2 gynnwys mis a blwyddyn
+
 # ________________________________________________________________________________
 # Confirm Client
 # ________________________________________________________________________________

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/DateFormFieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/DateFormFieldHelperSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.data.Form
+import play.api.data.Forms.single
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers.DateFormFieldHelper
+
+class DateFormFieldHelperSpec extends AnyWordSpecLike with Matchers {
+
+  "The date form mapping" should {
+
+    val mapping = DateFormFieldHelper.dateFieldMapping("exampleMsg")
+    val form = Form(single("date" -> mapping))
+    val exampleData = Map("date.day" -> "1", "date.month" -> "1", "date.year" -> "2020")
+
+    "return a valid result when binding with appropriate day/month/year fields" in {
+      form.bind(exampleData).hasErrors shouldBe false
+    }
+
+    "return a validation error when binding without day/month/year fields" in {
+      form.bind(Map("date.something" -> "1")).hasErrors shouldBe true
+    }
+
+    "parse and transform a valid date string when it is filled to the form" in {
+      form.fill("2020-01-01").data shouldBe exampleData
+    }
+
+    "fail to parse an invalid date string when it is filled to the form" in {
+      intercept[IllegalArgumentException](form.fill(""))
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/LocalDateFormatterSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/LocalDateFormatterSpec.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.data.FormError
+
+import java.time.LocalDate
+
+class LocalDateFormatterSpec extends AnyWordSpec with Matchers {
+
+  val msgPrefix = "page.service"
+
+  val formatter = new LocalDateFormatter(msgPrefix)
+
+  ".validateDayMonthYear" should {
+
+    "return no form errors when all date values are valid" in {
+      formatter.validateDayMonthYear("date", Some("11"), Some("11"), Some("2000")) shouldBe Nil
+    }
+
+    "return form errors" when {
+
+      "the day is invalid" in {
+        formatter.validateDayMonthYear("date", Some("f"), Some("11"), Some("2000")) shouldBe
+          Seq(FormError("date.day", formatter.invalidKey, Seq()))
+      }
+
+      "the month is invalid" in {
+        formatter.validateDayMonthYear("date", Some("11"), Some("f"), Some("2000")) shouldBe
+          Seq(FormError("date.month", formatter.invalidKey, Seq()))
+      }
+
+      "the year is invalid" in {
+        formatter.validateDayMonthYear("date", Some("11"), Some("11"), Some("f")) shouldBe
+          Seq(FormError("date.year", formatter.invalidKey, Seq()))
+      }
+
+      "the month and year are invalid" in {
+        formatter.validateDayMonthYear("date", Some("11"), Some("20"), Some("0")) shouldBe Seq(
+          FormError("date.month", formatter.invalidKey, Seq()),
+          FormError("date.year", formatter.invalidKey, Seq()))
+      }
+
+      "the day and year are invalid" in {
+        formatter.validateDayMonthYear("date", Some("50"), Some("11"), Some("0")) shouldBe Seq(
+          FormError("date.day", formatter.invalidKey, Seq()),
+          FormError("date.year", formatter.invalidKey, Seq()))
+      }
+
+      "the day and month are invalid" in {
+        formatter.validateDayMonthYear("date", Some("5.6"), Some("9.9"), Some("2000")) shouldBe Seq(
+          FormError("date.day", formatter.invalidKey, Seq()),
+          FormError("date.month", formatter.invalidKey, Seq()))
+      }
+
+      "all three fields are invalid" in {
+        formatter.validateDayMonthYear("date", Some("&%£"), Some("~@;"), Some("-_-")) shouldBe
+          Seq(FormError("date", formatter.invalidKey, Seq()))
+      }
+
+      "the day is empty" in {
+        formatter.validateDayMonthYear("date", None, Some("11"), Some("2000")) shouldBe
+          Seq(FormError("date.day", formatter.dayRequiredKey, Seq()))
+      }
+
+      "the month is empty" in {
+        formatter.validateDayMonthYear("date", Some("11"), None, Some("2000")) shouldBe
+          Seq(FormError("date.month", formatter.monthRequiredKey, Seq()))
+      }
+
+      "the year is empty" in {
+        formatter.validateDayMonthYear("date", Some("11"), Some("11"), None) shouldBe
+          Seq(FormError("date.year", formatter.yearRequiredKey, Seq()))
+      }
+
+      "the month and year are empty" in {
+        formatter.validateDayMonthYear("date", Some("11"), None, None) shouldBe Seq(
+          FormError("date.month", formatter.monthYearRequiredKey, Seq()),
+          FormError("date.year", formatter.monthYearRequiredKey, Seq()))
+      }
+
+      "the day and year are empty" in {
+        formatter.validateDayMonthYear("date", None, Some("11"), None) shouldBe Seq(
+          FormError("date.day", formatter.dayYearRequiredKey, Seq()),
+          FormError("date.year", formatter.dayYearRequiredKey, Seq()))
+      }
+
+      "the day and month are empty" in {
+        formatter.validateDayMonthYear("date", None, None, Some("2000")) shouldBe Seq(
+          FormError("date.day", formatter.dayMonthRequiredKey, Seq()),
+          FormError("date.month", formatter.dayMonthRequiredKey, Seq()))
+      }
+
+      "all three fields are empty" in {
+        formatter.validateDayMonthYear("date", None, None, None) shouldBe
+          Seq(FormError("date", formatter.allRequiredKey, Seq()))
+      }
+
+      "there are a mix of invalid and empty fields (empty takes precedence)" in {
+        formatter.validateDayMonthYear("date", Some("f"), None, Some("f")) shouldBe
+          Seq(FormError("date.month", formatter.monthRequiredKey, Seq()))
+      }
+    }
+  }
+
+  ".toDate" should {
+
+    "return a LocalDate when the provided values make a valid date" in {
+      formatter.toDate("date", 11, 11, 2000) shouldBe Right(LocalDate.parse("2000-11-11"))
+    }
+
+    "return a form error when the provided values do not make a valid date" in {
+      formatter.toDate("date", 31, 11, 2000) shouldBe Left(Seq(FormError("date", formatter.invalidKey)))
+    }
+  }
+
+  ".bind" should {
+
+    "return a LocalDate when binding was successful" in {
+      formatter.bind("date", Map("date.day" -> "11", "date.month" -> "11", "date.year" -> "2000")) shouldBe
+        Right(LocalDate.parse("2000-11-11"))
+    }
+
+    "return the form errors when binding was unsuccessful" in {
+      formatter.bind("date", Map("date.day" -> "fff", "date.month" -> "79", "date.year" -> "3.142")) shouldBe
+        Left(Seq(FormError("date", formatter.invalidKey)))
+    }
+  }
+
+  ".unbind" should {
+
+    "return form data from a LocalDate" in {
+      formatter.unbind("date", LocalDate.parse("2000-11-11")) shouldBe Map(
+        "date.day" -> "11",
+        "date.month" -> "11",
+        "date.year" -> "2000"
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/DateSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/DateSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.journey.clientFactPartials
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientFactForm
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.clientFactPartials.Date
+
+class DateSpec extends ViewSpecSupport {
+
+  val template: Date = app.injector.instanceOf[Date]
+  val fieldConfig: KnownFactsConfiguration = KnownFactsConfiguration("date", "", "text", 20)
+  implicit val journeyRequest: AgentJourneyRequest[?] =
+    new AgentJourneyRequest("", Journey(journeyType = AuthorisationRequest), request)
+
+  val listOfServices: Seq[String] = Seq("PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-PPT-ORG", "HMRC-PILLAR2-ORG")
+
+  val h1ContentMap: Map[String, String] = Map(
+    "PERSONAL-INCOME-RECORD" -> "What is your client’s date of birth?",
+    "HMRC-MTD-VAT" -> "When did the client’s VAT registration start?",
+    "HMRC-PPT-ORG" -> "When did your client’s registration start for Plastic Packaging Tax?",
+    "HMRC-PILLAR2-ORG" -> "What is your client’s registration date for Pillar 2 top-up taxes?"
+  )
+
+  val hintContentMap: Map[String, String] = Map(
+    "PERSONAL-INCOME-RECORD" -> "For example, 22 7 1981.",
+    "HMRC-MTD-VAT" -> "The date of registration is on the client’s VAT certificate. For example, 31 8 2015.",
+    "HMRC-PPT-ORG" -> "For example, 31 8 2022.",
+    "HMRC-PILLAR2-ORG" -> "The current filing member can find it on their Pillar 2 top-up taxes homepage. For example, 27 3 2026."
+  )
+
+  val errorContentMap: Map[String, String] = Map(
+    "PERSONAL-INCOME-RECORD" -> "Enter your client’s date of birth",
+    "HMRC-MTD-VAT" -> "Enter your client’s VAT registration date",
+    "HMRC-PPT-ORG" -> "Enter your client’s Plastic Packaging Tax registration date",
+    "HMRC-PILLAR2-ORG" -> "Enter your client’s date of registration to report Pillar 2 top-up taxes"
+  )
+
+  "The Date partial" should {
+
+    "render base components of a date form" which {
+
+      val form = EnterClientFactForm.form(fieldConfig, "", Set())
+      val view: HtmlFormat.Appendable = template(form, fieldConfig, "")
+      val doc: Document = Jsoup.parse(view.body)
+
+      "include a day input" in {
+        doc.extractByIndex("input", 1).value.attr("id") shouldBe "date.day"
+      }
+
+      "include a month input" in {
+        doc.extractByIndex("input", 2).value.attr("id") shouldBe "date.month"
+      }
+
+      "include a year input" in {
+        doc.extractByIndex("input", 3).value.attr("id") shouldBe "date.year"
+      }
+
+      "include a submission button" in {
+        doc.extractText(".govuk-button", 1).value shouldBe "Continue"
+      }
+    }
+
+    "render a page heading and form hint based on the service" which {
+
+      listOfServices.foreach { service =>
+
+        val msgPrefix = s"clientFact.$service.date"
+        val form = EnterClientFactForm.form(fieldConfig, service, Set())
+        val view: HtmlFormat.Appendable = template(form, fieldConfig, msgPrefix)
+        val doc: Document = Jsoup.parse(view.body)
+
+        s"has a legend containing the h1 for $service" in {
+          doc.extractText("legend > h1", 1).value shouldBe h1ContentMap(service)
+        }
+
+        s"has a form hint for $service" in {
+          doc.extractText(".govuk-hint", 1).value shouldBe hintContentMap(service)
+        }
+      }
+    }
+
+    "render an error when there are errors in the form" which {
+
+      listOfServices.foreach { service =>
+
+        val msgPrefix = s"clientFact.$service.date"
+        val form = EnterClientFactForm.form(fieldConfig, service, Set()).bind(Map("date" -> ""))
+        val view: HtmlFormat.Appendable = template(form, fieldConfig, msgPrefix)
+        val doc: Document = Jsoup.parse(view.body)
+
+        s"includes an error message specific for $service" in {
+          doc.extractText(".govuk-error-message", 1).value shouldBe s"Error: ${errorContentMap(service)}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I had to change a small bit of logic in the controller to prevent prepopulating the form with a blank string when there is no existing known fact. This was causing the date form helper to throw an exception (LocalDate.parse on a blank string).

I've also had to make a small change to the error summary to support the complex a11y needs of date inputs.