### PR TITLE
Apb 8960

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.actions
 
 import play.api.mvc.{ActionBuilder, AnyContent, DefaultActionBuilder}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, ClientJourneyRequest, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AgentFastTrackRequestWithRedirectUrls
 
 import javax.inject.{Inject, Singleton}
@@ -29,12 +29,15 @@ class Actions @Inject()(
     authActions:      AuthActions,
     getFastTrackUrlAction : GetFastTrackUrlAction
 ) {
-  def getJourney(journeyTypeFromUrl: JourneyType): ActionBuilder[AgentJourneyRequest, AnyContent] =
-    actionBuilder andThen authActions.agentAuthAction andThen getJourneyAction.journeyAction(journeyTypeFromUrl)
+  def getAgentJourney(journeyTypeFromUrl: JourneyType): ActionBuilder[AgentJourneyRequest, AnyContent] =
+    actionBuilder andThen authActions.agentAuthAction andThen getJourneyAction.agentJourneyAction(journeyTypeFromUrl)
 
-  def authenticate: ActionBuilder[AgentRequest, AnyContent] =
+  def agentAuthenticate: ActionBuilder[AgentRequest, AnyContent] =
     actionBuilder andThen authActions.agentAuthAction
     
   def getFastTrackUrl: ActionBuilder[AgentFastTrackRequestWithRedirectUrls, AnyContent] =
     actionBuilder andThen authActions.agentAuthAction andThen getFastTrackUrlAction.getFastTrackUrlAction
+    
+  def getClientJourney(taxService: String): ActionBuilder[ClientJourneyRequest, AnyContent]  =
+    actionBuilder andThen authActions.clientAuthActionWithEnrolmentCheck(taxService) andThen getJourneyAction.clientJourneyAction
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.invitationLink.ValidateLinkPartsResponse
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientServiceConfigurationService
 import uk.gov.hmrc.http.HttpReads.Implicits.*
@@ -44,7 +44,7 @@ class AgentClientRelationshipsConnector @Inject()(appConfig: AppConfig,
     .get(url"$agentClientRelationshipsUrl/client/$service/details/$clientId")
     .execute[Option[ClientDetailsResponse]]
 
-  def createAuthorisationRequest(journey: Journey)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[String] = {
+  def createAuthorisationRequest(journey: AgentJourney)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[String] = {
     val clientIdType = serviceConfig.firstClientDetailsFieldFor(journey.getService).clientIdType
     httpV2
       .post(url"$agentClientRelationshipsUrl/agent/${request.arn}/authorisation-request")
@@ -56,7 +56,7 @@ class AgentClientRelationshipsConnector @Inject()(appConfig: AppConfig,
       }
   }
 
-  def cancelAuthorisation(journey: Journey)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[Unit] = httpV2
+  def cancelAuthorisation(journey: AgentJourney)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[Unit] = httpV2
     .delete(url"$agentClientRelationshipsUrl/agent/${request.arn}/service/${journey.getService}/client/${serviceConfig.firstClientDetailsFieldFor(journey.getService).clientIdType}/${journey.clientId.get}")
     .execute[HttpResponse].map { response => response.status match {
       case NO_CONTENT => ()

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.AgentFastTrackForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, FastTrackErrors}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.*
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AgentFastTrackController @Inject()(mcc: MessagesControllerComponents,
-                                         journeyService: JourneyService,
+                                         journeyService: AgentJourneyService,
                                          serviceConfig: ClientServiceConfigurationService,
                                          actions: Actions,
                                          agentClientRelationshipsService: AgentClientRelationshipsService

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientConfirmationFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.ConfirmClientForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.ConfirmClientPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -31,12 +31,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmClientController @Inject()(mcc: MessagesControllerComponents,
-                                        journeyService: JourneyService,
+                                        journeyService: AgentJourneyService,
                                         confirmClientPage: ConfirmClientPage,
                                         actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -50,7 +50,7 @@ class ConfirmClientController @Inject()(mcc: MessagesControllerComponents,
       }
 
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationController.scala
@@ -41,7 +41,7 @@ class ConfirmationController @Inject()(mcc: MessagesControllerComponents,
   private def makeClientLink(authorisationRequestInfo: AuthorisationRequestInfo): String =
     s"${appConfig.appExternalUrl}/agent-client-relationships/appoint-someone-to-deal-with-HMRC-for-you/${authorisationRequestInfo.agentReference}/${authorisationRequestInfo.normalizedAgentName}/${serviceConfig.getUrlPart(authorisationRequestInfo.service)}"
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactController.scala
@@ -24,8 +24,8 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.config.CountryNamesLoader
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.KnownFactType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientFactForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey, JourneyExitType, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.EnterClientFactPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -35,7 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class EnterClientFactController @Inject()(mcc: MessagesControllerComponents,
                                           serviceConfig: ClientServiceConfigurationService,
-                                          journeyService: JourneyService,
+                                          journeyService: AgentJourneyService,
                                           enterKnownFactPage: EnterClientFactPage,
                                           actions: Actions,
                                           countryNamesLoader: CountryNamesLoader
@@ -51,13 +51,13 @@ class EnterClientFactController @Inject()(mcc: MessagesControllerComponents,
     else
       knownFactType.fieldConfiguration
 
-  private def knownFactForm(journey: Journey): Form[String] = EnterClientFactForm.form(
+  private def knownFactForm(journey: AgentJourney): Form[String] = EnterClientFactForm.form(
     journey.getKnownFactType.fieldConfiguration,
     journey.getService,
     validCountryCodes
   )
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -76,7 +76,7 @@ class EnterClientFactController @Inject()(mcc: MessagesControllerComponents,
       }
 
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientIdController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientIdController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientIdForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.EnterClientIdPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -31,13 +31,13 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class EnterClientIdController @Inject()(mcc: MessagesControllerComponents,
                                         serviceConfig: ClientServiceConfigurationService,
-                                        journeyService: JourneyService,
+                                        journeyService: AgentJourneyService,
                                         agentClientRelationshipsService: AgentClientRelationshipsService,
                                         enterClientIdPage: EnterClientIdPage,
                                         actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -50,7 +50,7 @@ class EnterClientIdController @Inject()(mcc: MessagesControllerComponents,
         ))
 
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/JourneyExitController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/JourneyExitController.scala
@@ -33,7 +33,7 @@ class JourneyExitController @Inject()(mcc: MessagesControllerComponents,
                                       actions: Actions
                                        )(implicit val executionContext: ExecutionContext, appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
 
-  def show(journeyType: JourneyType, exitType: JourneyExitType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType, exitType: JourneyExitType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleController.scala
@@ -23,8 +23,8 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.AgentRoleFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.ClientDetailsResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentRoleChangeType, Journey, JourneyExitType, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentRoleChangeType, AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectAgentRolePage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -34,12 +34,12 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SelectAgentRoleController @Inject()(mcc: MessagesControllerComponents,
                                           serviceConfig: ClientServiceConfigurationService,
-                                          journeyService: JourneyService,
+                                          journeyService: AgentJourneyService,
                                           selectAgentRolePage: SelectAgentRolePage,
                                           actions: Actions
                                        )(implicit val executionContext: ExecutionContext, appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
   
-  private def getAgentRoleChangeType(journey: Journey, options: Seq[String]): AgentRoleChangeType = {
+  private def getAgentRoleChangeType(journey: AgentJourney, options: Seq[String]): AgentRoleChangeType = {
     journey.getClientDetailsResponse.hasExistingRelationshipFor match {
       case Some(existing) if options.head == existing => AgentRoleChangeType.MainToSupporting
       case Some(_) => AgentRoleChangeType.SupportingToMain
@@ -47,7 +47,7 @@ class SelectAgentRoleController @Inject()(mcc: MessagesControllerComponents,
     }
   }
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -62,7 +62,7 @@ class SelectAgentRoleController @Inject()(mcc: MessagesControllerComponents,
       }
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientTypeFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectClientTypePage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -32,12 +32,12 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SelectClientTypeController @Inject()(mcc: MessagesControllerComponents,
                                            serviceConfig: ClientServiceConfigurationService,
-                                           journeyService: JourneyService,
+                                           journeyService: AgentJourneyService,
                                            selectClientTypePage: SelectClientTypePage,
                                            actions: Actions
                                           )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -47,7 +47,7 @@ class SelectClientTypeController @Inject()(mcc: MessagesControllerComponents,
       ))
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientServiceFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectClientServicePage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -32,12 +32,12 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SelectServiceController @Inject()(mcc: MessagesControllerComponents,
                                         serviceConfig: ClientServiceConfigurationService,
-                                        journeyService: JourneyService,
+                                        journeyService: AgentJourneyService,
                                         selectClientServicePage: SelectClientServicePage,
                                         actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -52,7 +52,7 @@ class SelectServiceController @Inject()(mcc: MessagesControllerComponents,
       }
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientServiceFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.ServiceRefinementPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -32,12 +32,12 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class ServiceRefinementController @Inject()(mcc: MessagesControllerComponents,
                                             serviceConfig: ClientServiceConfigurationService,
-                                            journeyService: JourneyService,
+                                            journeyService: AgentJourneyService,
                                             serviceRefinementPage: ServiceRefinementPage,
                                             actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType):
+  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -55,7 +55,7 @@ class ServiceRefinementController @Inject()(mcc: MessagesControllerComponents,
       }
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getJourney(journeyType).async:
+  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartJourneyController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartJourneyController.scala
@@ -20,7 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.{Actions, AgentRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -28,12 +28,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class StartJourneyController @Inject()(mcc: MessagesControllerComponents,
-                                       journeyService: JourneyService,
+                                       journeyService: AgentJourneyService,
                                        actions: Actions
                                       )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
   
-  def startJourney(journeyType: JourneyType): Action[AnyContent] = actions.authenticate.async:
+  def startJourney(journeyType: JourneyType): Action[AnyContent] = actions.agentAuthenticate.async:
     request =>
       given AgentRequest[?] = request
       

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/common/ServiceData.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/common/ServiceData.scala
@@ -23,7 +23,7 @@ case class ServiceData(
                         supportedAgentRoles: Seq[String] = Seq.empty,
                         supportedEnrolments: Seq[String] = Seq.empty,
                         serviceName: String,
-                        urlPart: String,
+                        urlPart: Map[String, Set[String]],
                         clientTypes: Set[String],
                         clientDetails: Seq[ClientDetailsConfiguration],
                         journeyErrors: Map[JourneyType, JourneyErrors] = Map(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourney.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourney.scala
@@ -19,18 +19,18 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, ClientStatus, KnownFactType}
 
-case class Journey(journeyType: JourneyType,
-                   clientType: Option[String] = None,
-                   clientService: Option[String] = None,
-                   clientId: Option[String] = None,
-                   clientDetailsResponse: Option[ClientDetailsResponse] = None,
-                   knownFact: Option[String] = None,
-                   agentType: Option[String] = None,
-                   clientConfirmed: Option[Boolean] = None,
-                   refinedService: Option[Boolean] = None,
-                   journeyComplete: Option[String] = None,
-                   confirmationClientName: Option[String] = None,
-                   confirmationService: Option[String] = None
+case class AgentJourney(journeyType: JourneyType,
+                        clientType: Option[String] = None,
+                        clientService: Option[String] = None,
+                        clientId: Option[String] = None,
+                        clientDetailsResponse: Option[ClientDetailsResponse] = None,
+                        knownFact: Option[String] = None,
+                        agentType: Option[String] = None,
+                        clientConfirmed: Option[Boolean] = None,
+                        refinedService: Option[Boolean] = None,
+                        journeyComplete: Option[String] = None,
+                        confirmationClientName: Option[String] = None,
+                        confirmationService: Option[String] = None
                   ):
 
   def getClientTypeWithDefault: String = clientType.getOrElse("")
@@ -57,7 +57,7 @@ case class Journey(journeyType: JourneyType,
       case ClientDetailsResponse(_, _, _, _, _, _, None) => Some(JourneyExitType.NoAuthorisationExists)
     }
 
-object Journey:
-  implicit lazy val format: OFormat[Journey] = Json.format[Journey]
+object AgentJourney:
+  implicit lazy val format: OFormat[AgentJourney] = Json.format[AgentJourney]
 
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
@@ -16,22 +16,11 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
+import play.api.libs.json.{Format, Json}
 
-class JourneyStateSpec extends AnyWordSpecLike with Matchers {
+case class ClientJourney(
+                          journeyType: JourneyType, consent: Option[Boolean] = None)
 
-  "JourneyState format" should {
-    JourneyState.values.foreach(value => s"write $value to a json string and read it back" in {
-      val jsString = JsString(value.toString)
-      Json.toJson[JourneyState](value) shouldBe jsString
-      Json.fromJson[JourneyState](jsString) shouldBe JsSuccess(value)
-    })
-
-    "fail to read an unknown value" in {
-      Json.fromJson[JourneyState](JsString("invalid")) shouldBe JsError("Invalid JourneyState")
-    }
-  }
-
+object ClientJourney {
+  implicit val format: Format[ClientJourney] = Json.format[ClientJourney]
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourneyRequest.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourneyRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,7 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
 
-import play.api.mvc.Request
-import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.AgentRequest
+import play.api.mvc.{Request, WrappedRequest}
 
-class AgentJourneyRequest[A](override val arn: String,
-                             val journey: AgentJourney,
-                             override val request: Request[A])
-  extends AgentRequest[A](arn, request)
+class ClientJourneyRequest[A](val journey: ClientJourney,
+                              val request: Request[A]) extends WrappedRequest[A](request)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/JourneyType.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/JourneyType.scala
@@ -20,14 +20,15 @@ import play.api.libs.json.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.inverseMapping
 
 enum JourneyType:
-  case AuthorisationRequest, AgentCancelAuthorisation
+  case AuthorisationRequest, AgentCancelAuthorisation, ClientResponse
 
   override def toString: String = inverseMapping(this)
 
 object JourneyType:
   val mapping: Map[String, JourneyType] = Map(
     "authorisation-request" -> AuthorisationRequest,
-    "agent-cancel-authorisation" -> AgentCancelAuthorisation
+    "agent-cancel-authorisation" -> AgentCancelAuthorisation,
+    "client-response" -> ClientResponse
   )
   val inverseMapping: Map[JourneyType, String] = mapping.map(_.swap)
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/JourneyRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/JourneyRepository.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.DurationInt
 class JourneyRepository @Inject()(mongo: MongoComponent)(implicit ec: ExecutionContext)
   extends SessionCacheRepository(
     mongoComponent = mongo,
-    collectionName = "client-relationships",
+    collectionName = "journey",
     ttl = 15.minutes,
     timestampSupport = new CurrentTimestampSupport(),
     sessionIdKey = SessionKeys.sessionId

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.services
 
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentDetails, AuthorisationRequestInfo, ClientDetailsResponse}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
@@ -27,17 +27,17 @@ import scala.concurrent.Future
 @Singleton
 class AgentClientRelationshipsService @Inject()(agentClientRelationshipsConnector: AgentClientRelationshipsConnector) {
 
-  def getClientDetails(clientId: String, journey: Journey)(implicit hc: HeaderCarrier): Future[Option[ClientDetailsResponse]] =
+  def getClientDetails(clientId: String, journey: AgentJourney)(implicit hc: HeaderCarrier): Future[Option[ClientDetailsResponse]] =
     agentClientRelationshipsConnector.getClientDetails(journey.getService, clientId)
     
   def getClientDetails(clientId: String, service: String)(implicit hc: HeaderCarrier): Future[Option[ClientDetailsResponse]] =
     agentClientRelationshipsConnector.getClientDetails(service, clientId)
 
-  def createAuthorisationRequest(journey: Journey)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[String] = {
+  def createAuthorisationRequest(journey: AgentJourney)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[String] = {
     agentClientRelationshipsConnector.createAuthorisationRequest(journey)
   }
 
-  def cancelAuthorisation(journey: Journey)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[Unit] = {
+  def cancelAuthorisation(journey: AgentJourney)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[Unit] = {
     agentClientRelationshipsConnector.cancelAuthorisation(journey)
   }
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentJourneyService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentJourneyService.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.services
+
+import play.api.mvc.Request
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.repositories.JourneyRepository
+import uk.gov.hmrc.mongo.cache.DataKey
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AgentJourneyService @Inject()(val journeyRepository: JourneyRepository,
+                                    val serviceConfig: ClientServiceConfigurationService
+                                       )(implicit executionContext: ExecutionContext, appConfig: AppConfig) extends JourneyService[AgentJourney] {
+
+  override val dataKey: DataKey[AgentJourney] = DataKey("AgentJourneySessionData")
+  
+  def newJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
+    journeyType = journeyType
+  )
+
+  def nextPageUrl(journeyType: JourneyType)(implicit request: Request[Any]): Future[String] = {
+    for {
+      journey <- getJourney()
+    } yield journey match {
+      case Some(journey) if journey.journeyType != journeyType => routes.StartJourneyController.startJourney(journeyType).url
+      case Some(journey) if journey.journeyComplete.nonEmpty => appConfig.agentServicesAccountHomeUrl
+      case Some(journey) => {
+        if (journey.clientService.isEmpty) routes.SelectClientTypeController.show(journeyType).url
+        else if (serviceConfig.requiresRefining(journey.clientService.get) && journey.refinedService.isEmpty) routes.ServiceRefinementController.show(journeyType).url
+        else if (journey.clientDetailsResponse.isEmpty) routes.EnterClientIdController.show(journeyType).url
+        else if (journey.clientDetailsResponse.get.knownFactType.nonEmpty && journey.knownFact.isEmpty) routes.EnterClientFactController.show(journeyType).url
+        else if (journey.clientConfirmed.isEmpty) routes.ConfirmClientController.show(journeyType).url
+        else if (journey.clientConfirmed.contains(false)) routes.StartJourneyController.startJourney(journeyType).url
+        else if (journeyType == JourneyType.AuthorisationRequest && serviceConfig.supportsAgentRoles(journey.getService) && journey.agentType.isEmpty) routes.SelectAgentRoleController.show(journeyType).url
+        else if (journey.getExitType(journeyType, journey.getClientDetailsResponse, serviceConfig.getSupportedAgentRoles(journey.getService)).nonEmpty) routes.JourneyExitController.show(journeyType, journey.getExitType(journeyType, journey.getClientDetailsResponse, serviceConfig.getSupportedAgentRoles(journey.getService)).get).url
+        else routes.CheckYourAnswersController.show(journeyType).url
+      }
+      case _ => routes.StartJourneyController.startJourney(journeyType).url
+    }
+  }
+  
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientJourneyService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientJourneyService.scala
@@ -16,21 +16,18 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.services
 
-import play.api.libs.json.Format
-import play.api.mvc.Request
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
+import com.google.inject.{Inject, Singleton}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.repositories.JourneyRepository
 import uk.gov.hmrc.mongo.cache.DataKey
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
-trait JourneyService[T]:
-  val journeyRepository: JourneyRepository
-  val serviceConfig: ClientServiceConfigurationService
-  val dataKey: DataKey[T]
-  def saveJourney(journey: T)(implicit request: Request[?], ec: ExecutionContext, format: Format[T]): Future[Unit] =
-    journeyRepository.putSession(dataKey, journey).map(_ => ())
-  def getJourney(implicit request: Request[Any], format: Format[T]): Future[Option[T]] =
-    journeyRepository.getFromSession(dataKey)
-  def deleteAllAnswersInSession(implicit request: Request[Any]): Future[Unit] =
-    journeyRepository.cacheRepo.deleteEntity(request)
+@Singleton
+class ClientJourneyService @Inject()(val journeyRepository: JourneyRepository,
+                                     val serviceConfig: ClientServiceConfigurationService)(implicit executionContext: ExecutionContext, appConfig: AppConfig) extends JourneyService[ClientJourney] {
+
+  override val dataKey: DataKey[ClientJourney] = DataKey("ClientJourneySessionData")
+  
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ServiceConstants.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ServiceConstants.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.services
+
+trait ServiceConstants:
+
+  val incomeTax = "income-tax"
+  val vat = "vat"
+  val incomeRecordViewer = "income-record-viewer"
+  val trustsAndEstates = "trusts-and-estates"
+  val trustsAndEstateNonTaxable = "trusts-and-estates-non-taxable"
+  val capitalGainsTaxUkProperty = "capital-gains-tax-uk-property"
+  val plasticPackagingTax = "plastic-packaging-tax"
+  val countryByCountryReporting = "country-by-country-reporting"
+  val pillar2 = "pillar-2"
+  
+  val HMRCMTDIT: String = "HMRC-MTD-IT"
+  val HMRCNI: String = "HMRC-NI"
+  val HMRCPT: String = "HMRC-PT"
+  val HMRCMTDITSUPP: String = "HMRC-MTD-IT-SUPP"
+  val PERSONALINCOMERECORD: String = "PERSONAL-INCOME-RECORD"
+  val HMRCMTDVAT: String = "HMRC-MTD-VAT"
+  val HMRCTERSORG: String = "HMRC-TERS-ORG"
+  val HMRCTERSNTORG: String = "HMRC-TERSNT-ORG"
+  val HMRCCGTPD: String = "HMRC-CGT-PD"
+  val HMRCPPTORG: String = "HMRC-PPT-ORG"
+  val HMRCCBCORG: String = "HMRC-CBC-ORG"
+  val HMRCPILLAR2ORG: String = "HMRC-PILLAR2-ORG"

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackControllerSpec.scala
@@ -23,9 +23,9 @@ import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes as journeyRoutes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes as fastTrackRoutes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.testOnly.routes as testRoutes
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentFastTrackRequest, ClientDetailsResponse, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, JourneyService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
 
 class AgentFastTrackControllerSpec extends ComponentSpecHelper with AuthStubs with AgentClientRelationshipStub with ScalaFutures {
@@ -165,7 +165,7 @@ class AgentFastTrackControllerSpec extends ComponentSpecHelper with AuthStubs wi
      "knownFact" -> agentFastTrackRequest.knownFact.fold(Seq.empty)(Seq(_))
    )
 
-   def toJourney(agentFastTrackRequest: AgentFastTrackRequest,clientDetailsResponse: Option[ClientDetailsResponse], journeyType: JourneyType = journeyType): Journey =
+   def toJourney(agentFastTrackRequest: AgentFastTrackRequest,clientDetailsResponse: Option[ClientDetailsResponse], journeyType: JourneyType = journeyType): AgentJourney =
      journeyService.newJourney(JourneyType.AuthorisationRequest)
        .copy(
          clientService = Some(agentFastTrackRequest.service),
@@ -185,7 +185,7 @@ class AgentFastTrackControllerSpec extends ComponentSpecHelper with AuthStubs wi
      hasExistingRelationshipFor = None
    )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
   val serviceConfig: ClientServiceConfigurationService = app.injector.instanceOf[ClientServiceConfigurationService]
 
   override def beforeEach(): Unit = {

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/AgentJourneyExitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/AgentJourneyExitControllerISpec.scala
@@ -19,20 +19,20 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyExitType, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
-class JourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs {
+class AgentJourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  private val authorisationRequestJourney: Journey = Journey(
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
     clientId = Some("AB123"),
     clientDetailsResponse = Some(ClientDetailsResponse("Test Name", None, None, Seq("AA11AA"), Some(KnownFactType.PostalCode), false, None))
   )
-  private val agentCancelAuthorisationJourney: Journey = Journey(
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(
     JourneyType.AgentCancelAuthorisation,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
@@ -40,7 +40,7 @@ class JourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs {
     clientDetailsResponse = Some(ClientDetailsResponse("Test Name", None, None, Seq("AA11AA"), Some(KnownFactType.PostalCode), false, None))
   )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientControllerISpec.scala
@@ -18,9 +18,9 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, ClientStatus, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
@@ -29,7 +29,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   val testCgtRef: String = "XMCGTP123456789"
   val testPostcode: String = "AA11AA"
 
-  def noAuthJourney(journeyType: JourneyType): Journey = Journey(
+  def noAuthJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -38,7 +38,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def noAuthJourneyWithSupportedRoles(journeyType: JourneyType): Journey = Journey(
+  def noAuthJourneyWithSupportedRoles(journeyType: JourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-MTD-IT"),
@@ -47,7 +47,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def alreadyAuthJourney(journeyType: JourneyType): Journey = Journey(
+  def alreadyAuthJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -56,7 +56,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def existingPendingRequestJourney: Journey = Journey(
+  def existingPendingRequestJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -65,7 +65,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def clientInsolventJourney: Journey = Journey(
+  def clientInsolventJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -74,7 +74,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def clientStatusInvalidJourney: Journey = Journey(
+  def clientStatusInvalidJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -83,7 +83,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))
@@ -93,7 +93,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   "GET /authorisation-request/confirm-client" should {
     "redirect to enter client id when it is missing" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"), clientService = Some("HMRC-MTD-IT"))))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"), clientService = Some("HMRC-MTD-IT"))))
       val result = get(routes.ConfirmClientController.show(JourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.EnterClientIdController.show(JourneyType.AuthorisationRequest).url

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationControllerISpec.scala
@@ -20,8 +20,8 @@ import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentCancelAuthorisationResponse, AuthorisationRequestInfo}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
@@ -64,19 +64,19 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
     )
   )
 
-  private val completeCancellationJourney: Journey = Journey(
+  private val completeCancellationJourney: AgentJourney = AgentJourney(
     JourneyType.AgentCancelAuthorisation,
     journeyComplete = Some("2024-12-25"),
     confirmationClientName = Some(testClientName),
     confirmationService = Some("HMRC-MTD-IT")
   )
 
-  private val completeCreateAuthorisationRequestJourney: Journey = Journey(
+  private val completeCreateAuthorisationRequestJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     journeyComplete = Some(testInvitationId)
   )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactControllerISpec.scala
@@ -20,8 +20,8 @@ import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.KnownFactType.PostalCode
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyType, JourneyExitType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType, JourneyExitType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
@@ -30,7 +30,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   val testNino: String = "AB123456C"
   val testPostcode: String = "AA11AA"
 
-  def testItsaJourney(journeyType: JourneyType): Journey = Journey(
+  def testItsaJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-MTD-IT"),
@@ -38,7 +38,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
     Some(ClientDetailsResponse("", None, None, Seq(testPostcode), Some(KnownFactType.PostalCode), false, None))
   )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))
@@ -48,7 +48,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   "GET /authorisation-request/client-fact" should {
     "redirect to the journey start when previous answers are missing" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))))
       val result = get(routes.EnterClientFactController.show(JourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
@@ -86,7 +86,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
-      val updatedJourney = await(journeyService.getJourney()(request))
+      val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe None
     }
     "leave existing answers intact when submitting the same answer" in {
@@ -95,7 +95,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
-      val updatedJourney = await(journeyService.getJourney()(request))
+      val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe Some(true)
     }
     "show an error when no selection is made" in {
@@ -109,7 +109,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   "GET /agent-cancel-authorisation/client-fact" should {
     "redirect to the journey start when previous answers are missing" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
       val result = get(routes.EnterClientFactController.show(JourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url
@@ -147,7 +147,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
-      val updatedJourney = await(journeyService.getJourney()(request))
+      val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe None
     }
     "leave existing answers intact when submitting the same answer" in {
@@ -156,7 +156,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
-      val updatedJourney = await(journeyService.getJourney()(request))
+      val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe Some(true)
     }
     "show an error when no selection is made" in {

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientIdControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientIdControllerISpec.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
@@ -60,12 +60,12 @@ class EnterClientIdControllerISpec extends ComponentSpecHelper with AuthStubs {
     case "HMRC-PILLAR2-ORG" => "PlrId"
   }
 
-  private val personalAuthorisationRequestJourney: Journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))
-  private val businessAuthorisationRequestJourney: Journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("business"))
-  private val trustAuthorisationRequestJourney: Journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"))
-  private val personalAgentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation, clientType = Some("personal"))
-  private val businessAgentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation, clientType = Some("business"))
-  private val trustAgentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation, clientType = Some("trust"))
+  private val personalAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))
+  private val businessAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("business"))
+  private val trustAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"))
+  private val personalAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("personal"))
+  private val businessAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("business"))
+  private val trustAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("trust"))
 
   private val optionsForPersonal: Seq[String] = Seq("HMRC-MTD-IT", "PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-CGT-PD", "HMRC-PPT-ORG")
   private val optionsForBusiness: Seq[String] = Seq("HMRC-MTD-VAT", "HMRC-PPT-ORG", "HMRC-CBC-ORG", "HMRC-PILLAR2-ORG")
@@ -93,18 +93,18 @@ class EnterClientIdControllerISpec extends ComponentSpecHelper with AuthStubs {
     case "HMRC-PILLAR2-ORG" => examplePlrId
   }
 
-  private val allClientTypeAuthJourneys: List[Journey] = List(
+  private val allClientTypeAuthJourneys: List[AgentJourney] = List(
     personalAuthorisationRequestJourney,
     businessAuthorisationRequestJourney,
     trustAuthorisationRequestJourney
   )
-  private val allClientTypeDeAuthJourneys: List[Journey] = List(
+  private val allClientTypeDeAuthJourneys: List[AgentJourney] = List(
     personalAgentCancelAuthorisationJourney,
     businessAgentCancelAuthorisationJourney,
     trustAgentCancelAuthorisationJourney
   )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))
@@ -120,7 +120,7 @@ class EnterClientIdControllerISpec extends ComponentSpecHelper with AuthStubs {
     }
     "redirect to the journey start when no service present" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))))
       val result = get(routes.EnterClientIdController.show(JourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
@@ -166,7 +166,7 @@ class EnterClientIdControllerISpec extends ComponentSpecHelper with AuthStubs {
     }
     "redirect to the journey start when no client type present" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
       val result = get(routes.EnterClientIdController.show(JourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleControllerISpec.scala
@@ -19,13 +19,13 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyExitType, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class SelectAgentRoleControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
   val journeyType: JourneyType = JourneyType.AuthorisationRequest // this controller is only used on AuthorisationRequest journeys
 
   override def beforeEach(): Unit = {
@@ -48,7 +48,7 @@ class SelectAgentRoleControllerISpec extends ComponentSpecHelper with AuthStubs 
   val clientDetailsWithExistingMain: ClientDetailsResponse = clientDetailsWithOutExisting.copy(hasExistingRelationshipFor = Some("HMRC-MTD-IT"))
   val clientDetailsWithExistingSupp: ClientDetailsResponse = clientDetailsWithOutExisting.copy(hasExistingRelationshipFor = Some("HMRC-MTD-IT-SUPP"))
 
-  private val journey = Journey(
+  private val journey = AgentJourney(
     journeyType = journeyType,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
@@ -58,7 +58,7 @@ class SelectAgentRoleControllerISpec extends ComponentSpecHelper with AuthStubs 
     agentType = None
   )
 
-  val agentRoleJourneys: Seq[Journey] = List(
+  val agentRoleJourneys: Seq[AgentJourney] = List(
     journey,
     journey.copy(clientDetailsResponse = Some(clientDetailsWithExistingMain)),
     journey.copy(clientDetailsResponse = Some(clientDetailsWithExistingSupp))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeControllerISpec.scala
@@ -18,16 +18,16 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class SelectClientTypeControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceControllerISpec.scala
@@ -18,18 +18,18 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyState, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyState, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  private val personalAuthorisationRequestJourney: Journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))
-  private val businessAuthorisationRequestJourney: Journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("business"))
-  private val trustAuthorisationRequestJourney: Journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"))
-  private val personalAgentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation, clientType = Some("personal"))
-  private val businessAgentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation, clientType = Some("business"))
-  private val trustAgentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation, clientType = Some("trust"))
+  private val personalAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))
+  private val businessAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("business"))
+  private val trustAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"))
+  private val personalAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("personal"))
+  private val businessAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("business"))
+  private val trustAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("trust"))
 
   private val optionsForPersonal: Seq[String] = Seq("HMRC-MTD-IT", "PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-CGT-PD", "HMRC-PPT-ORG")
   private val optionsForBusiness: Seq[String] = Seq("HMRC-MTD-VAT", "HMRC-PPT-ORG", "HMRC-CBC-ORG", "HMRC-PILLAR2-ORG")
@@ -43,18 +43,18 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
     "trust" -> optionsForTrust
   )
 
-  private val allClientTypeAuthJourneys: List[Journey] = List(
+  private val allClientTypeAuthJourneys: List[AgentJourney] = List(
     personalAuthorisationRequestJourney,
     businessAuthorisationRequestJourney,
     trustAuthorisationRequestJourney
   )
-  private val allClientTypeDeAuthJourneys: List[Journey] = List(
+  private val allClientTypeDeAuthJourneys: List[AgentJourney] = List(
     personalAgentCancelAuthorisationJourney,
     businessAgentCancelAuthorisationJourney,
     trustAgentCancelAuthorisationJourney
   )
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))
@@ -70,7 +70,7 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
     }
     "redirect to the journey start when no client type present" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AuthorisationRequest, clientType = None)))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = None)))
       val result = get(routes.SelectServiceController.show(JourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
@@ -126,7 +126,7 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
     }
     "redirect to the journey start when no client type present" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(Journey(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
+      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
       val result = get(routes.SelectServiceController.show(JourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementControllerISpec.scala
@@ -17,15 +17,14 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
-import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyState, JourneyType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.services.JourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class ServiceRefinementControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+  val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))
@@ -33,7 +32,7 @@ class ServiceRefinementControllerISpec extends ComponentSpecHelper with AuthStub
   }
 
   "GET /authorisation-request/refine-service" should {
-    val journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
       val result = get(routes.ServiceRefinementController.show(JourneyType.AuthorisationRequest).url)
@@ -56,7 +55,7 @@ class ServiceRefinementControllerISpec extends ComponentSpecHelper with AuthStub
   }
 
   "POST /authorisation-request/refine-service" should {
-    val journey = Journey(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to the next page after storing answer" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
@@ -76,7 +75,7 @@ class ServiceRefinementControllerISpec extends ComponentSpecHelper with AuthStub
   }
 
   "GET /agent-cancel-authorisation/refine-service" should {
-    val journey = Journey(journeyType = JourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
       val result = get(routes.ServiceRefinementController.show(JourneyType.AgentCancelAuthorisation).url)
@@ -99,7 +98,7 @@ class ServiceRefinementControllerISpec extends ComponentSpecHelper with AuthStub
   }
 
   "POST /agent-cancel-authorisation/refine-service" should {
-    val journey = Journey(journeyType = JourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to the enter client id page after storing answer" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartAgentJourneyControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartAgentJourneyControllerISpec.scala
@@ -20,7 +20,7 @@ import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
-class StartJourneyControllerISpec extends ComponentSpecHelper with AuthStubs {
+class StartAgentJourneyControllerISpec extends ComponentSpecHelper with AuthStubs {
 
   "GET /authorisation-request/" should {
     "redirect to the select client type page" in {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/AgentClientRelationshipsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/AgentClientRelationshipsServiceSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{Journey, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentClientRelationshipsService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -55,7 +55,7 @@ class AgentClientRelationshipsServiceSpec extends AnyWordSpecLike with Matchers 
     false,
     None
   )
-  val testJourney: Journey = Journey(
+  val testJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     Some("testType"),
     Some("testService")

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.actions
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status.OK
+import play.api.libs.json.Json
+import play.api.mvc.{Action, ActionRefiner, AnyContent, AnyContentAsEmpty, DefaultActionBuilder, Request, Result, Results}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, redirectLocation, status}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentJourneyService, ClientJourneyService}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GetClientJourneyActionSpec extends AnyWordSpecLike with Matchers with OptionValues with BeforeAndAfterEach with GuiceOneAppPerSuite:
+
+  val fakeAuthAction: ActionRefiner[Request, Request] = new ActionRefiner[Request, Request] {
+    override def refine[A](request: Request[A]): Future[Either[Result, Request[A]]] =
+      Future.successful(Right[Result, Request[A]](request))
+
+    override protected def executionContext: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  }
+
+  class FakeController(getJourneyAction: GetJourneyAction,
+                       actionBuilder: DefaultActionBuilder) {
+    def route: Action[AnyContent] =
+      (actionBuilder andThen fakeAuthAction andThen getJourneyAction.clientJourneyAction) {
+        journeyRequest =>
+          Results.Ok(Json.toJson(journeyRequest.journey).toString)
+      }
+  }
+
+  val mockAgentJourneyService: AgentJourneyService = mock[AgentJourneyService]
+  val mockClientJourneyService: ClientJourneyService = mock[ClientJourneyService]
+  val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  val defaultActionBuilder: DefaultActionBuilder = app.injector.instanceOf[DefaultActionBuilder]
+
+  given ExecutionContext = app.injector.instanceOf[ExecutionContext]
+
+  override def afterEach(): Unit = {
+    reset(mockAgentJourneyService)
+    reset(mockClientJourneyService)
+    super.afterEach()
+  }
+
+  val testController = new FakeController(
+    new GetJourneyAction(mockAgentJourneyService, mockClientJourneyService, appConfig),
+    defaultActionBuilder
+  )
+
+  val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  val testArn = "testArn"
+
+  "clientJourneyAction" should {
+    "successfully retrieve journey and continue" in {
+      val testJourney = ClientJourney(
+        JourneyType.ClientResponse
+      )
+      when(mockClientJourneyService.getJourney(any(), any()))
+        .thenReturn(Future.successful(Some(testJourney)))
+
+      val result = testController.route()(fakeRequest)
+
+      status(result) shouldBe OK
+      contentAsJson(result).as[ClientJourney] shouldBe testJourney
+    }
+
+    "create a new journey if it cannot retrieve journey" in {
+      when(mockClientJourneyService.getJourney(any(), any()))
+        .thenReturn(Future.successful(None))
+
+      val result = testController.route()(fakeRequest)
+
+      status(result) shouldBe OK
+      //contentAsJson(result).as[ClientJourney] shouldBe ClientJourney(journeyType = ClientResponse)
+
+    }
+  }
+
+

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
@@ -95,7 +95,7 @@ class GetClientJourneyActionSpec extends AnyWordSpecLike with Matchers with Opti
       val result = testController.route()(fakeRequest)
 
       status(result) shouldBe OK
-      //contentAsJson(result).as[ClientJourney] shouldBe ClientJourney(journeyType = ClientResponse)
+      contentAsJson(result).as[ClientJourney] shouldBe ClientJourney(journeyType = ClientResponse)
 
     }
   }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
@@ -88,7 +88,7 @@ class GetClientJourneyActionSpec extends AnyWordSpecLike with Matchers with Opti
       contentAsJson(result).as[ClientJourney] shouldBe testJourney
     }
 
-    "create a new journey if it cannot retrieve journey" in {
+    "create a new journey if one doesn't exist in Mongo" in {
       when(mockClientJourneyService.getJourney(any(), any()))
         .thenReturn(Future.successful(None))
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyStateSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyStateSpec.scala
@@ -20,17 +20,17 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
 
-class JourneyTypeSpec extends AnyWordSpecLike with Matchers {
+class AgentJourneyStateSpec extends AnyWordSpecLike with Matchers {
 
-  "JourneyType format" should {
-    JourneyType.values.foreach(value => s"write $value to a json string and read it back" in {
+  "JourneyState format" should {
+    JourneyState.values.foreach(value => s"write $value to a json string and read it back" in {
       val jsString = JsString(value.toString)
-      Json.toJson[JourneyType](value) shouldBe jsString
-      Json.fromJson[JourneyType](jsString) shouldBe JsSuccess(value)
+      Json.toJson[JourneyState](value) shouldBe jsString
+      Json.fromJson[JourneyState](jsString) shouldBe JsSuccess(value)
     })
 
     "fail to read an unknown value" in {
-      Json.fromJson[JourneyType](JsString("invalid")) shouldBe JsError("Invalid JourneyType")
+      Json.fromJson[JourneyState](JsString("invalid")) shouldBe JsError("Invalid JourneyState")
     }
   }
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyTypeSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyTypeSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
+
+class AgentJourneyTypeSpec extends AnyWordSpecLike with Matchers {
+
+  "JourneyType format" should {
+    JourneyType.values.foreach(value => s"write $value to a json string and read it back" in {
+      val jsString = JsString(value.toString)
+      Json.toJson[JourneyType](value) shouldBe jsString
+      Json.fromJson[JourneyType](jsString) shouldBe JsSuccess(value)
+    })
+
+    "fail to read an unknown value" in {
+      Json.fromJson[JourneyType](JsString("invalid")) shouldBe JsError("Invalid JourneyType")
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.services
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matchers with ServiceConstants {
+
+  val services = new ClientServiceConfigurationService
+
+  val serviceNames: List[String] = List(incomeTax, vat, capitalGainsTaxUkProperty, plasticPackagingTax, pillar2, trustsAndEstates, trustsAndEstateNonTaxable, incomeRecordViewer, countryByCountryReporting)
+
+  "getServiceKeys" should {
+      s"return enrolments supported by $incomeTax" in {
+        services.getServiceKeys(incomeTax).get shouldBe Set(HMRCMTDIT, HMRCNI, HMRCPT)
+      }
+      s"return enrolments supported by $vat" in {
+        services.getServiceKeys(vat).get shouldBe Set(HMRCMTDVAT)
+      }
+      s"return enrolments supported by $capitalGainsTaxUkProperty" in {
+      services.getServiceKeys(capitalGainsTaxUkProperty).get shouldBe Set(HMRCCGTPD)
+      }
+      s"return enrolments supported by $trustsAndEstates" in {
+      services.getServiceKeys(trustsAndEstates).get shouldBe Set(HMRCTERSORG)
+      }
+      s"return enrolments supported by $trustsAndEstateNonTaxable" in {
+      services.getServiceKeys(trustsAndEstateNonTaxable).get shouldBe Set(HMRCTERSNTORG)
+      }
+      s"return enrolments supported by $pillar2" in {
+        services.getServiceKeys(pillar2).get shouldBe Set(HMRCPILLAR2ORG)
+      }
+      s"return enrolments supported by $incomeRecordViewer" in {
+      services.getServiceKeys(incomeRecordViewer).get shouldBe Set(HMRCNI, HMRCPT)
+      }
+      s"return enrolments supported by $plasticPackagingTax" in {
+      services.getServiceKeys(plasticPackagingTax).get shouldBe Set(HMRCPPTORG)
+      }
+      s"return enrolments supported by $countryByCountryReporting" in {
+      services.getServiceKeys(countryByCountryReporting).get shouldBe Set(HMRCCBCORG)
+     }
+      "return None when service is unknown" in {
+      services.getServiceKeys("unknown") shouldBe None
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentCancelAuthorisationCompletePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentCancelAuthorisationCompletePageSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AgentCancelAuthorisationResponse
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.AgentCancelAuthorisationCompletePage
 
@@ -50,7 +50,7 @@ class AgentCancelAuthorisationCompletePageSpec extends ViewSpecSupport {
     date = "2024-12-25"
   )
 
-  private val completeJourney: Journey = Journey(
+  private val completeJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     journeyComplete = Some("2024-12-25"),
     confirmationClientName = Some(testClientName),

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentJourneyExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentJourneyExitPageSpec.scala
@@ -23,12 +23,12 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.JourneyExitPage
 
-class JourneyExitPageSpec extends ViewSpecSupport {
+class AgentJourneyExitPageSpec extends ViewSpecSupport {
 
   val viewTemplate: JourneyExitPage = app.injector.instanceOf[JourneyExitPage]
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
   case class ExpectedStrings(authorisationTitle: String, cancelAuthorisationTitle: String)
   private val supportedErrorCodes: Map[JourneyExitType, ExpectedStrings] = Map(

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CheckYourAnswersPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CheckYourAnswersPageSpec.scala
@@ -33,7 +33,7 @@ class CheckYourAnswersPageSpec extends ViewSpecSupport {
   private val clientName = "Test Name"
   private val servicesWithoutAgentRoles = Seq("PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-CGT-PD", "HMRC-PPT-ORG", "HMRC-CBC-ORG", "HMRC-PILLAR2-ORG", "HMRC-TERS-ORG")
   private val basicClientDetails = ClientDetailsResponse(clientName, None, None, Seq(exampleKnownFact), Some(KnownFactType.PostalCode), false, None)
-  private val basicJourney: Journey = Journey(
+  private val basicJourney: AgentJourney = AgentJourney(
     journeyType = journeyType,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
@@ -44,12 +44,12 @@ class CheckYourAnswersPageSpec extends ViewSpecSupport {
     agentType = None
   )
 
-  def singleAgentRequestJourney(service: String): Journey = basicJourney.copy(
+  def singleAgentRequestJourney(service: String): AgentJourney = basicJourney.copy(
     clientService = Some(service),
     agentType = None
   )
 
-  def agentRoleBasedRequestJourney(service: String, role: String): Journey = basicJourney.copy(
+  def agentRoleBasedRequestJourney(service: String, role: String): AgentJourney = basicJourney.copy(
     clientService = Some(service),
     agentType = Some(role)
   )

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmCancellationPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmCancellationPageSpec.scala
@@ -37,7 +37,7 @@ class ConfirmCancellationPageSpec extends ViewSpecSupport {
 
   private val services = Seq("HMRC-MTD-IT", "PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-CGT-PD", "HMRC-PPT-ORG", "HMRC-CBC-ORG", "HMRC-PILLAR2-ORG", "HMRC-TERS-ORG")
   private val basicClientDetails = ClientDetailsResponse(clientName, None, None, Seq(exampleKnownFact), Some(KnownFactType.PostalCode), false, None)
-  private val basicJourney: Journey = Journey(
+  private val basicJourney: AgentJourney = AgentJourney(
     journeyType = journeyType,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPageSpec.scala
@@ -31,11 +31,11 @@ class ConfirmClientPageSpec extends ViewSpecSupport {
 
   val viewTemplate: ConfirmClientPage = app.injector.instanceOf[ConfirmClientPage]
 
-  private val authorisationRequestJourney: Journey = Journey(
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     clientDetailsResponse = Some(ClientDetailsResponse("TestName", None, None, Nil, None, false, None))
   )
-  private val agentCancelAuthorisationJourney: Journey = Journey(
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(
     JourneyType.AgentCancelAuthorisation,
     clientDetailsResponse = Some(ClientDetailsResponse("TestName", None, None, Nil, None, false, None))
   )

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePageSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AuthorisationRequestInfo
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.CreateAuthorisationRequestCompletePage
 
@@ -54,7 +54,7 @@ class CreateAuthorisationRequestCompletePageSpec extends ViewSpecSupport {
     expiryDate = LocalDate.of(2025, 1, 1)
   )
 
-  private val completeJourney: Journey = Journey(
+  private val completeJourney: AgentJourney = AgentJourney(
     JourneyType.AuthorisationRequest,
     journeyComplete = Some(testInvitationId)
   )

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPageSpec.scala
@@ -29,8 +29,8 @@ class EnterClientFactPageSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
   case class ExpectedStrings(authorisationTitle: String, cancelAuthorisationTitle: String)
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientIdPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientIdPageSpec.scala
@@ -30,8 +30,8 @@ class EnterClientIdPageSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientIdPage = app.injector.instanceOf[EnterClientIdPage]
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
   val ninoField: ClientDetailsConfiguration = ClientDetailsConfiguration(
     name = "nino",

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePageSpec.scala
@@ -61,7 +61,7 @@ class SelectAgentRolePageSpec extends ViewSpecSupport {
   val clientDetailsWithExistingMain: ClientDetailsResponse = clientDetailsWithOutExisting.copy(hasExistingRelationshipFor = Some(mainRole))
   val clientDetailsWithExistingSupp: ClientDetailsResponse = clientDetailsWithOutExisting.copy(hasExistingRelationshipFor = Some(supportingRole))
 
-  private val journey = Journey(
+  private val journey = AgentJourney(
     journeyType = journeyType,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
@@ -71,7 +71,7 @@ class SelectAgentRolePageSpec extends ViewSpecSupport {
     agentType = None
   )
 
-  val agentRoleJourneys: Seq[(Journey, AgentRoleChangeType)] = Seq(
+  val agentRoleJourneys: Seq[(AgentJourney, AgentRoleChangeType)] = Seq(
     (journey, AgentRoleChangeType.NewRelationship),
     (journey.copy(clientDetailsResponse = Some(clientDetailsWithExistingMain)), AgentRoleChangeType.MainToSupporting),
     (journey.copy(clientDetailsResponse = Some(clientDetailsWithExistingSupp)), AgentRoleChangeType.SupportingToMain)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePageSpec.scala
@@ -63,7 +63,7 @@ class SelectClientServicePageSpec extends ViewSpecSupport {
 
   "SelectClientServicePage for authorisation request view" should {
     implicit val journeyRequest: AgentJourneyRequest[?] =
-      new AgentJourneyRequest("", Journey(journeyType = AuthorisationRequest), request)
+      new AgentJourneyRequest("", AgentJourney(journeyType = AuthorisationRequest), request)
     val formForPersonal: Form[String] = SelectFromOptionsForm.form("clientService", optionsForPersonal, AuthorisationRequest.toString)
     val view: HtmlFormat.Appendable = viewTemplate(formForPersonal, "personal", optionsForPersonal)
     val doc: Document = Jsoup.parse(view.body)
@@ -163,7 +163,7 @@ class SelectClientServicePageSpec extends ViewSpecSupport {
 
   "SelectClientServicePage for cancel authorisation view" should {
     implicit val journeyRequest: AgentJourneyRequest[?] =
-      new AgentJourneyRequest("", Journey(journeyType = AgentCancelAuthorisation), request)
+      new AgentJourneyRequest("", AgentJourney(journeyType = AgentCancelAuthorisation), request)
     val formForPersonal: Form[String] = SelectFromOptionsForm.form("clientService", optionsForPersonal, AgentCancelAuthorisation.toString)
     val view: HtmlFormat.Appendable = viewTemplate(formForPersonal, "personal", optionsForPersonal)
     val doc: Document = Jsoup.parse(view.body)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientTypePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientTypePageSpec.scala
@@ -40,7 +40,7 @@ class SelectClientTypePageSpec extends ViewSpecSupport {
   }
 
   "SelectClientType for authorisation request view" should {
-    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", Journey(journeyType = JourneyType.AuthorisationRequest), request)
+    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", AgentJourney(journeyType = JourneyType.AuthorisationRequest), request)
     val options: Seq[String] = Seq("personal", "business", "trust")
     val form: Form[String] = SelectFromOptionsForm.form("clientType", options, "authorisation-request")
     val view: HtmlFormat.Appendable = viewTemplate(form, options)
@@ -67,7 +67,7 @@ class SelectClientTypePageSpec extends ViewSpecSupport {
   }
 
   "SelectClientType for cancel authorisation view" should {
-    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", Journey(journeyType = JourneyType.AgentCancelAuthorisation), request)
+    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation), request)
     val options: Seq[String] = Seq("personal", "business", "trust")
     val form: Form[String] = SelectFromOptionsForm.form("clientType", options, "agent-cancel-authorisation")
     val view: HtmlFormat.Appendable = viewTemplate(form, options)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPageSpec.scala
@@ -47,7 +47,7 @@ class ServiceRefinementPageSpec extends ViewSpecSupport {
 
   "ServiceRefinementPage for authorisation request view" should {
     implicit val journeyRequest: AgentJourneyRequest[?] =
-      new AgentJourneyRequest("", Journey(journeyType = AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG")), request)
+      new AgentJourneyRequest("", AgentJourney(journeyType = AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG")), request)
     val refinementForm: Form[String] = SelectFromOptionsForm.form("clientService", optionsForTrust, AuthorisationRequest.toString)
     val view: HtmlFormat.Appendable = viewTemplate(refinementForm, optionsForTrust)
     val doc: Document = Jsoup.parse(view.body)
@@ -90,7 +90,7 @@ class ServiceRefinementPageSpec extends ViewSpecSupport {
 
   "ServiceRefinementPage for cancel authorisation view" should {
     implicit val journeyRequest: AgentJourneyRequest[?] =
-      new AgentJourneyRequest("", Journey(journeyType = AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG")), request)
+      new AgentJourneyRequest("", AgentJourney(journeyType = AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG")), request)
     val refinementForm: Form[String] = SelectFromOptionsForm.form("clientService", optionsForTrust, AgentCancelAuthorisation.toString)
     val view: HtmlFormat.Appendable = viewTemplate(refinementForm, optionsForTrust)
     val doc: Document = Jsoup.parse(view.body)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/CountrySpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/CountrySpec.scala
@@ -29,8 +29,8 @@ class CountrySpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
       s"EnterClientFactPage for country code ${j.journeyType.toString} view" should {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/DateSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/DateSpec.scala
@@ -21,7 +21,7 @@ import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientFactForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, Journey}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.clientFactPartials.Date
@@ -31,7 +31,7 @@ class DateSpec extends ViewSpecSupport {
   val template: Date = app.injector.instanceOf[Date]
   val fieldConfig: KnownFactsConfiguration = KnownFactsConfiguration("date", "", "text", 20)
   implicit val journeyRequest: AgentJourneyRequest[?] =
-    new AgentJourneyRequest("", Journey(journeyType = AuthorisationRequest), request)
+    new AgentJourneyRequest("", AgentJourney(journeyType = AuthorisationRequest), request)
 
   val listOfServices: Seq[String] = Seq("PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-PPT-ORG", "HMRC-PILLAR2-ORG")
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/EmailSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/EmailSpec.scala
@@ -29,8 +29,8 @@ class EmailSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
     List("HMRC-CBC-ORG","HMRC-CBC-NONUK-ORG").foreach(enrolment =>

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/PostcodeSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/PostcodeSpec.scala
@@ -29,8 +29,8 @@ class PostcodeSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: Journey = Journey(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: Journey = Journey(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
       s"EnterClientFactPage for postcode ${j.journeyType.toString} view" should {


### PR DESCRIPTION
Adds client auth action with a journey session refiner to bring a session into scope for our client endpoints.
As a result of client using a session too, refactored the JourneySession to a trait and extended this for agent and client. 
Added some constants so we can access them in our service configuration and our test suites.