### PR TITLE
APB-8954 Add route/controller for client-led CYA

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
@@ -34,10 +34,13 @@ class Actions @Inject()(
 
   def agentAuthenticate: ActionBuilder[AgentRequest, AnyContent] =
     actionBuilder andThen authActions.agentAuthAction
-    
+
   def getFastTrackUrl: ActionBuilder[AgentFastTrackRequestWithRedirectUrls, AnyContent] =
     actionBuilder andThen authActions.agentAuthAction andThen getFastTrackUrlAction.getFastTrackUrlAction
-    
-  def getClientJourney(taxService: String): ActionBuilder[ClientJourneyRequest, AnyContent]  =
+
+  def getClientJourney(taxService: String): ActionBuilder[ClientJourneyRequest, AnyContent] =
     actionBuilder andThen authActions.clientAuthActionWithEnrolmentCheck(taxService) andThen getJourneyAction.clientJourneyAction
+
+  def clientAuthenticate: ActionBuilder[ClientJourneyRequest, AnyContent] =
+    actionBuilder andThen authActions.clientAuthAction andThen getJourneyAction.clientJourneyAction
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetJourneyAction.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetJourneyAction.scala
@@ -37,7 +37,7 @@ class GetJourneyAction @Inject()(agentJourneyService: AgentJourneyService,
 
     override def invokeBlock[A](request: AgentRequest[A], block: AgentJourneyRequest[A] => Future[Result]): Future[Result] =
       given AgentRequest[A] = request
-      agentJourneyService.getJourney().flatMap {
+      agentJourneyService.getJourney.flatMap {
         case Some(journey) if journey.journeyType == journeyTypeFromUrl =>
           block(new AgentJourneyRequest(request.arn, journey, request.request))
         case _ =>
@@ -49,7 +49,7 @@ class GetJourneyAction @Inject()(agentJourneyService: AgentJourneyService,
         
       override def invokeBlock[A](request: Request[A], block: ClientJourneyRequest[A] => Future[Result]): Future[Result] =
         given Request[A] = request
-        clientJourneyService.getJourney().flatMap {
+        clientJourneyService.getJourney.flatMap {
           mJourney => block(ClientJourneyRequest(mJourney.getOrElse(ClientJourney(journeyType = ClientResponse)), request))
         }
         

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import com.google.inject.{Inject, Singleton}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CheckYourAnswerController @Inject()(mcc: MessagesControllerComponents,
+                                          actions: Actions,
+                                          agentClientRelationshipsConnector: AgentClientRelationshipsConnector)
+                                         (implicit ec: ExecutionContext,
+                                          appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
+
+  def show: Action[AnyContent] = actions.clientAuthenticate:
+    implicit request =>
+      if (request.journey.consent.isDefined) Ok // TODO render view
+      else BadRequest // TODO implement tailored page which gives some guidance to user
+
+  def submit: Action[AnyContent] = actions.clientAuthenticate.async:
+    implicit request =>
+      val consentAnswer = request.journey.consent
+      val invitationId = request.journey.invitationId
+      (consentAnswer, invitationId) match {
+        case (Some(true), Some(invId)) =>
+          agentClientRelationshipsConnector.acceptAuthorisation(invId).map: _ =>
+            Redirect("routes.controllers.client.ConfirmationController.show") // TODO add controller reverse routing
+        case (Some(false), Some(invId)) =>
+          agentClientRelationshipsConnector.rejectAuthorisation(invId).map: _ =>
+            Redirect("routes.controllers.client.ConfirmationController.show") // TODO add controller reverse routing
+        case _ =>
+          Future.successful(BadRequest) // TODO implement tailored page which gives some guidance to user
+      }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AuthorisationRequestInfo.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AuthorisationRequestInfo.scala
@@ -17,9 +17,8 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.models
 
 import play.api.libs.functional.syntax.*
-import play.api.libs.json.{Format, JsString, Reads, Writes, __}
+import play.api.libs.json.{Reads, __}
 
-import java.time.format.DateTimeFormatter
 import java.time.LocalDate
 
 case class AuthorisationRequestInfo(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
@@ -18,8 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
 
 import play.api.libs.json.{Format, Json}
 
-case class ClientJourney(
-                          journeyType: JourneyType, consent: Option[Boolean] = None)
+case class ClientJourney(journeyType: JourneyType, invitationId: Option[String] = None, consent: Option[Boolean] = None)
 
 object ClientJourney {
   implicit val format: Format[ClientJourney] = Json.format[ClientJourney]

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -54,3 +54,6 @@ POST        /agents/fast-track                                                  
 
 # Client URLs --------------------------------------------------------------------------------------------------------------
 GET        /appoint-someone-to-deal-with-HMRC-for-you/:uid/:normalizedAgentName/:taxService uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.StartController.show(uid: String, normalizedAgentName: String, taxService: String)
+
+GET        /authorisation-response/check-answer                                         uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.CheckYourAnswerController.show
+POST       /authorisation-response/check-answer                                         uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.CheckYourAnswerController.submit

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnectorISpec.scala
@@ -20,11 +20,11 @@ import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.invitationLink.ValidateLinkPartsResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, ClientStatus, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.ComponentSpecHelper
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, ComponentSpecHelper}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.http.{HeaderCarrier, JsValidationException, UpstreamErrorResponse}
 
-class AgentClientRelationshipsConnectorISpec extends ComponentSpecHelper {
+class AgentClientRelationshipsConnectorISpec extends ComponentSpecHelper with AgentClientRelationshipStub {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   val testConnector: AgentClientRelationshipsConnector = app.injector.instanceOf[AgentClientRelationshipsConnector]
@@ -115,4 +115,23 @@ class AgentClientRelationshipsConnectorISpec extends ComponentSpecHelper {
     }
   }
 
+  "acceptAuthorisation" should:
+
+    "return nothing when a 204 status is received" in:
+      givenAcceptAuthorisation("ABC123", NO_CONTENT)
+      await(testConnector.acceptAuthorisation("ABC123")) shouldEqual ()
+
+    "throw an exception when a non-204 status is received" in:
+      givenAcceptAuthorisation("ABC123", INTERNAL_SERVER_ERROR)
+      intercept[Exception](await(testConnector.acceptAuthorisation("ABC123")))
+
+  "rejectAuthorisation" should :
+
+    "return nothing when a 204 status is received" in:
+      givenRejectAuthorisation("ABC123", NO_CONTENT)
+      await(testConnector.rejectAuthorisation("ABC123")) shouldEqual ()
+
+    "throw an exception when a non-204 status is received" in:
+      givenRejectAuthorisation("ABC123", INTERNAL_SERVER_ERROR)
+      intercept[Exception](await(testConnector.rejectAuthorisation("ABC123")))
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerControllerISpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import play.api.http.Status.*
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourney
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientJourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
+
+class CheckYourAnswerControllerISpec extends ComponentSpecHelper with AuthStubs with AgentClientRelationshipStub:
+
+  val journeyService: ClientJourneyService = app.injector.instanceOf[ClientJourneyService]
+
+  val journeyModel: ClientJourney = ClientJourney(ClientResponse, invitationId = Some("ABC123"), consent = Some(true))
+
+  override def beforeEach(): Unit = {
+    await(journeyService.deleteAllAnswersInSession(request))
+    super.beforeEach()
+  }
+
+  "The show action" should:
+
+    "return status 200 OK" when:
+
+      "a consent answer is retrieved from the session" in:
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel))
+        val result = get(routes.CheckYourAnswerController.show.url)
+        result.status shouldBe OK
+
+    "return status 400 BAD_REQUEST" when:
+
+      "a consent answer is not present in the session" in:
+        authoriseAsClient()
+        val result = get(routes.CheckYourAnswerController.show.url)
+        result.status shouldBe BAD_REQUEST
+
+  "The submit action" should:
+
+    "redirect the user to the confirmation controller" when:
+
+      "the user accepts the invitation and a successful response is received from the backend" in:
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel))
+        givenAcceptAuthorisation("ABC123", NO_CONTENT)
+        val result = post(routes.CheckYourAnswerController.submit.url)(Map())
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe "routes.controllers.client.ConfirmationController.show"
+
+      "the user rejects the invitation and a successful response is received from the backend" in:
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel.copy(consent = Some(false))))
+        givenRejectAuthorisation("ABC123", NO_CONTENT)
+        val result = post(routes.CheckYourAnswerController.submit.url)(Map())
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe "routes.controllers.client.ConfirmationController.show"
+
+    "return status 400 BAD_REQUEST" when:
+
+      "a consent answer is not present in the session" in:
+        authoriseAsClient()
+        val result = post(routes.CheckYourAnswerController.submit.url)(Map())
+        result.status shouldBe BAD_REQUEST
+
+    "return status 500 INTERNAL_SERVER_ERROR" when:
+
+      "the user accepts the invitation but an unexpected response is received from the backend" in:
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel))
+        givenAcceptAuthorisation("ABC123", INTERNAL_SERVER_ERROR)
+        val result = post(routes.CheckYourAnswerController.submit.url)(Map())
+        result.status shouldBe INTERNAL_SERVER_ERROR
+
+      "the user rejects the invitation but an unexpected response is received from the backend" in :
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel.copy(consent = Some(false))))
+        givenRejectAuthorisation("ABC123", INTERNAL_SERVER_ERROR)
+        val result = post(routes.CheckYourAnswerController.submit.url)(Map())
+        result.status shouldBe INTERNAL_SERVER_ERROR

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AgentClientRelationshipStub.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AgentClientRelationshipStub.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.utils
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.test.Helpers.{NOT_FOUND, OK}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.{stubGet, stubPost}
 
 trait AgentClientRelationshipStub {
 
@@ -28,4 +28,9 @@ trait AgentClientRelationshipStub {
   def givenNotFoundForServiceAndClient(service: String, clientId: String): StubMapping = stubGet(
     s"/agent-client-relationships/client/$service/details/$clientId", NOT_FOUND, "")
 
+  def givenAcceptAuthorisation(invitationId: String, status: Int): StubMapping = stubPost(
+    s"/agent-client-relationships/authorisation-response/accept/$invitationId", status, "")
+
+  def givenRejectAuthorisation(invitationId: String, status: Int): StubMapping = stubPost(
+    s"/agent-client-relationships/authorisation-response/reject/$invitationId", status, "")
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AuthStubs.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AuthStubs.scala
@@ -39,4 +39,13 @@ trait AuthStubs {
     ).toString
   )
 
+  def authoriseAsClient(): StubMapping = stubPost(
+    "/auth/authorise",
+    OK,
+    Json.obj(
+      "affinityGroup" -> "Individual",
+      "confidenceLevel" -> 250,
+      "allEnrolments" -> Json.arr()
+    ).toString
+  )
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/WiremockHelper.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/WiremockHelper.scala
@@ -16,14 +16,13 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.utils
 
-import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
-import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import com.github.tomakehurst.wiremock.WireMockServer
-import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.IntegrationPatience
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 
 object WiremockHelper extends Eventually with IntegrationPatience {
 
@@ -85,7 +84,7 @@ object WiremockHelper extends Eventually with IntegrationPatience {
 
 trait WiremockHelper {
 
-  import WiremockHelper._
+  import WiremockHelper.*
 
   lazy val wmConfig: WireMockConfiguration = wireMockConfig().port(wiremockPort)
   lazy val wireMockServer: WireMockServer  = new WireMockServer(wmConfig)


### PR DESCRIPTION
The auth action I added is the same as the previous one but without the specific enrolment check, due to not having the tax service in this URL