### PR TITLE
APB-8957 Fix to pass agent name into client-led start page

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartController.scala
@@ -35,7 +35,7 @@ class StartController @Inject()(agentClientRelationshipsConnector: AgentClientRe
                                 serviceConfigurationService: ClientServiceConfigurationService,
                                 authoriseAgentStartPage: AuthoriseAgentStartPage,
                                 mcc: MessagesControllerComponents
-                                            )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
+                               )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
 
  def show(uid: String, normalizedAgentName: String, taxService: String): Action[AnyContent] = Action.async:
 
@@ -49,6 +49,6 @@ class StartController @Inject()(agentClientRelationshipsConnector: AgentClientRe
            case Left("AGENT_NOT_FOUND") => Redirect("routes.ClientExitController.show(AGENT_NOT_FOUND)")
            case Left("AGENT_SUSPENDED") => Redirect("routes.ClientExitController.show(AGENT_SUSPENDED)")
            case Left(_) => Redirect("routes.ClientExitController.show(SERVER_ERROR)")
-           case Right(_) => Ok(authoriseAgentStartPage(normalizedAgentName, taxService, uid))
+           case Right(response) => Ok(authoriseAgentStartPage(response.name, taxService, uid))
          }
-     else Future.successful(NotFound(s"TODO: NOT FOUND urlPart ${taxService} for Client controller/template"))
+     else Future.successful(NotFound(s"TODO: NOT FOUND urlPart $taxService for Client controller/template"))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
 
+import org.jsoup.Jsoup
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
@@ -29,9 +30,9 @@ class StartControllerSpec extends ComponentSpecHelper with ScalaFutures with Aut
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   val testUid = "ABCD"
-  val testNormalizedAgentName = "abc_ltd"
+  val testNormalizedAgentName = "test-name"
   val testTaxService = "income-tax"
-  val testName = "Test Name"
+  val testAgentName = "Test Name"
 
   val validTaxServiceNames: List[String] = List(
     "income-tax",
@@ -46,7 +47,7 @@ class StartControllerSpec extends ComponentSpecHelper with ScalaFutures with Aut
   def getValidateLinkResponseUrl(uid: String, normalizedAgentName: String) = s"/agent-client-relationships/agent/agent-reference/uid/$uid/$normalizedAgentName"
 
   val testValidateLinkResponseJson: JsObject = Json.obj(
-    "name" -> testName,
+    "name" -> testAgentName,
   )
 
   val serviceConfigurationService: ClientServiceConfigurationService = app.injector.instanceOf[ClientServiceConfigurationService]
@@ -93,6 +94,8 @@ class StartControllerSpec extends ComponentSpecHelper with ScalaFutures with Aut
 
         val result = get(routes.StartController.show(testUid, testNormalizedAgentName, taxService).url)
         result.status shouldBe OK
+        val body = Jsoup.parse(result.body)
+        body.select("h1").text() should include(testAgentName)
       }
 
     }


### PR DESCRIPTION
Fixing of the start button link has already been covered in an ongoing branch