### PR TITLE
APB-8958 confirmation page for clients

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.actions
 
 import play.api.mvc.{ActionBuilder, AnyContent, DefaultActionBuilder}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, ClientJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, ClientJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AgentFastTrackRequestWithRedirectUrls
 
 import javax.inject.{Inject, Singleton}
@@ -29,7 +29,7 @@ class Actions @Inject()(
     authActions:      AuthActions,
     getFastTrackUrlAction : GetFastTrackUrlAction
 ) {
-  def getAgentJourney(journeyTypeFromUrl: JourneyType): ActionBuilder[AgentJourneyRequest, AnyContent] =
+  def getAgentJourney(journeyTypeFromUrl: AgentJourneyType): ActionBuilder[AgentJourneyRequest, AnyContent] =
     actionBuilder andThen authActions.agentAuthAction andThen getJourneyAction.agentJourneyAction(journeyTypeFromUrl)
 
   def agentAuthenticate: ActionBuilder[AgentRequest, AnyContent] =

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetJourneyAction.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetJourneyAction.scala
@@ -19,8 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.actions
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionFunction, Request, Result}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, ClientJourney, ClientJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType, ClientJourney, ClientJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentJourneyService, ClientJourneyService}
 
 import javax.inject.{Inject, Singleton}
@@ -32,7 +31,7 @@ class GetJourneyAction @Inject()(agentJourneyService: AgentJourneyService,
                                  appConfig: AppConfig
                                 )(implicit ec: ExecutionContext) {
 
-  def agentJourneyAction(journeyTypeFromUrl: JourneyType): ActionFunction[AgentRequest, AgentJourneyRequest] = new ActionFunction[AgentRequest, AgentJourneyRequest]:
+  def agentJourneyAction(journeyTypeFromUrl: AgentJourneyType): ActionFunction[AgentRequest, AgentJourneyRequest] = new ActionFunction[AgentRequest, AgentJourneyRequest]:
     override protected def executionContext: ExecutionContext = ec
 
     override def invokeBlock[A](request: AgentRequest[A], block: AgentJourneyRequest[A] => Future[Result]): Future[Result] =
@@ -50,7 +49,7 @@ class GetJourneyAction @Inject()(agentJourneyService: AgentJourneyService,
       override def invokeBlock[A](request: Request[A], block: ClientJourneyRequest[A] => Future[Result]): Future[Result] =
         given Request[A] = request
         clientJourneyService.getJourney.flatMap {
-          mJourney => block(ClientJourneyRequest(mJourney.getOrElse(ClientJourney(journeyType = ClientResponse)), request))
+          mJourney => block(ClientJourneyRequest(mJourney.getOrElse(ClientJourney(journeyType = "authorisation-response")), request))
         }
         
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/binders/UrlBinders.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/binders/UrlBinders.scala
@@ -18,19 +18,19 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.binders
 
 import play.api.mvc.PathBindable
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyExitType, AgentJourneyType}
 
 object UrlBinders:
-  implicit val journeyTypeBinder: PathBindable[JourneyType] = getJourneyTypeBinder
+  implicit val journeyTypeBinder: PathBindable[AgentJourneyType] = getJourneyTypeBinder
 
-  private def getJourneyTypeBinder = new PathBindable[JourneyType]:
+  private def getJourneyTypeBinder = new PathBindable[AgentJourneyType]:
 
-    override def bind(key: String, value: String): Either[String, JourneyType] =
-      JourneyType.mapping
+    override def bind(key: String, value: String): Either[String, AgentJourneyType] =
+      AgentJourneyType.mapping
         .get(value).map(Right(_))
         .getOrElse(Left(s"Invalid journey type: $value"))
 
-    override def unbind(key: String, value: JourneyType): String =
+    override def unbind(key: String, value: AgentJourneyType): String =
       value.toString
 
   implicit val journeyExitTypeBinder: PathBindable[JourneyExitType] = getJourneyExitTypeBinder

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.AgentFastTrackForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, FastTrackErrors}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -37,7 +37,7 @@ class AgentFastTrackController @Inject()(mcc: MessagesControllerComponents,
                                          agentClientRelationshipsService: AgentClientRelationshipsService
                                         )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport {
 
-  lazy val journeyType: JourneyType = JourneyType.AuthorisationRequest
+  lazy val journeyType: AgentJourneyType = AgentJourneyType.AuthorisationRequest
 
   private def stripWhiteSpaces(str: String): String = str.trim.replaceAll("\\s", "")
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentController.scala
@@ -47,7 +47,9 @@ class ConfirmConsentController @Inject()(mcc: MessagesControllerComponents,
       (request.journey.serviceKey, request.journey.agentName) match {
         case (Some(service), Some(agentName)) =>
           val agentRole = determineAgentRole(service)
-          val form = ConfirmConsentForm.form(agentName, agentRole, service)
+          val form = if request.journey.consent.isDefined
+            then ConfirmConsentForm.form(agentName, agentRole, service).fill(request.journey.consent.get)
+            else ConfirmConsentForm.form(agentName, agentRole, service)
           Ok(confirmConsentView(form, agentRole))
         case _ => BadRequest // TODO implement tailored page which gives some guidance to user
       }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationController.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import com.google.inject.{Inject, Singleton}
+import play.api.{Logger, Logging}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentClientRelationshipsService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ConfirmationPage
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ConfirmationController @Inject()(mcc: MessagesControllerComponents,
+                                       actions: Actions,
+                                       agentClientRelationshipsService: AgentClientRelationshipsService,
+                                       confirmationPage: ConfirmationPage
+                                         )
+                                      (implicit ec: ExecutionContext,
+                                          appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport with Logging:
+
+  def show: Action[AnyContent] = actions.clientAuthenticate.async:
+    implicit request =>
+      request.journey.journeyComplete match {
+        case Some(invitationId) =>
+          agentClientRelationshipsService.getAuthorisationRequestForClient(invitationId = invitationId).map {
+            case Some(authorisationRequestInfo) =>
+              Ok(confirmationPage(authorisationRequestInfo))
+            case None =>
+              throw new RuntimeException(s"Authorisation request not found for invitationId: $invitationId")
+          }
+        case _ => {
+          logger.warn(s"Redirecting to MYTA as client journey is not valid for confirmation page - ${request.journey}")
+          Future.successful(Redirect(appConfig.acmExternalUrl))
+        }
+      }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientConfirmationFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.ConfirmClientForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.ConfirmClientPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -36,7 +36,7 @@ class ConfirmClientController @Inject()(mcc: MessagesControllerComponents,
                                         actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -50,7 +50,7 @@ class ConfirmClientController @Inject()(mcc: MessagesControllerComponents,
       }
 
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentCancelAuthorisationResponse, AuthorisationRequestInfo}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.{AgentCancelAuthorisationCompletePage, CreateAuthorisationRequestCompletePage}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +41,7 @@ class ConfirmationController @Inject()(mcc: MessagesControllerComponents,
   private def makeClientLink(authorisationRequestInfo: AuthorisationRequestInfo): String =
     s"${appConfig.appExternalUrl}/agent-client-relationships/appoint-someone-to-deal-with-HMRC-for-you/${authorisationRequestInfo.agentReference}/${authorisationRequestInfo.normalizedAgentName}/${serviceConfig.getUrlPart(authorisationRequestInfo.service)}"
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -49,14 +49,14 @@ class ConfirmationController @Inject()(mcc: MessagesControllerComponents,
       else
         val journeyCompleteString = journeyRequest.journey.journeyComplete.get
         journeyType match
-          case JourneyType.AuthorisationRequest =>
+          case AgentJourneyType.AuthorisationRequest =>
             agentClientRelationshipsService.getAuthorisationRequest(invitationId = journeyCompleteString).map {
               case Some(authorisationRequestInfo) =>
                 Ok(createAuthorisationRequestCompletePage(authorisationRequestInfo, makeClientLink(authorisationRequestInfo)))
               case None =>
                 throw new RuntimeException(s"Authorisation request not found for invitationId: $journeyCompleteString")
             }
-          case JourneyType.AgentCancelAuthorisation =>
+          case AgentJourneyType.AgentCancelAuthorisation =>
             agentClientRelationshipsService.getAgentDetails().map {
               case Some(agentDetails) => Ok(agentCancelAuthorisationCompletePage(AgentCancelAuthorisationResponse(
                 clientName = journeyRequest.journey.confirmationClientName.getOrElse(""),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.config.CountryNamesLoader
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.KnownFactType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientFactForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyExitType, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.EnterClientFactPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -57,7 +57,7 @@ class EnterClientFactController @Inject()(mcc: MessagesControllerComponents,
     validCountryCodes
   )
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -76,7 +76,7 @@ class EnterClientFactController @Inject()(mcc: MessagesControllerComponents,
       }
 
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientIdController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientIdController.scala
@@ -20,7 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientIdForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentClientRelationshipsService, ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.EnterClientIdPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -37,7 +37,7 @@ class EnterClientIdController @Inject()(mcc: MessagesControllerComponents,
                                         actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 
@@ -50,7 +50,7 @@ class EnterClientIdController @Inject()(mcc: MessagesControllerComponents,
         ))
 
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/JourneyExitController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/JourneyExitController.scala
@@ -20,7 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyExitType, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.JourneyExitPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -33,7 +33,7 @@ class JourneyExitController @Inject()(mcc: MessagesControllerComponents,
                                       actions: Actions
                                        )(implicit val executionContext: ExecutionContext, appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
 
-  def show(journeyType: JourneyType, exitType: JourneyExitType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType, exitType: JourneyExitType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.AgentRoleFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.ClientDetailsResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentRoleChangeType, AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentRoleChangeType, AgentJourney, JourneyExitType, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectAgentRolePage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -47,7 +47,7 @@ class SelectAgentRoleController @Inject()(mcc: MessagesControllerComponents,
     }
   }
 
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -62,7 +62,7 @@ class SelectAgentRoleController @Inject()(mcc: MessagesControllerComponents,
       }
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientTypeFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentJourneyService, ClientServiceConfigurationService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectClientTypePage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -38,7 +38,7 @@ class SelectClientTypeController @Inject()(mcc: MessagesControllerComponents,
                                            actions: Actions
                                           )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -48,7 +48,7 @@ class SelectClientTypeController @Inject()(mcc: MessagesControllerComponents,
       ))
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientServiceFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectClientServicePage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -37,7 +37,7 @@ class SelectServiceController @Inject()(mcc: MessagesControllerComponents,
                                         actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -52,7 +52,7 @@ class SelectServiceController @Inject()(mcc: MessagesControllerComponents,
       }
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientServiceFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.ServiceRefinementPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -37,7 +37,7 @@ class ServiceRefinementController @Inject()(mcc: MessagesControllerComponents,
                                             actions: Actions
                                        )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
-  def show(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
+  def show(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType):
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey
@@ -55,7 +55,7 @@ class ServiceRefinementController @Inject()(mcc: MessagesControllerComponents,
       }
       
 
-  def onSubmit(journeyType: JourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
+  def onSubmit(journeyType: AgentJourneyType): Action[AnyContent] = actions.getAgentJourney(journeyType).async:
     journeyRequest =>
       given AgentJourneyRequest[?] = journeyRequest
       val journey = journeyRequest.journey

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartJourneyController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartJourneyController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.i18n.I18nSupport
 import play.api.mvc.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.{Actions, AgentRequest}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -33,7 +33,7 @@ class StartJourneyController @Inject()(mcc: MessagesControllerComponents,
                                       )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with I18nSupport:
   
   
-  def startJourney(journeyType: JourneyType): Action[AnyContent] = actions.agentAuthenticate.async:
+  def startJourney(journeyType: AgentJourneyType): Action[AnyContent] = actions.agentAuthenticate.async:
     request =>
       given AgentRequest[?] = request
       

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AuthorisationRequestInfoForClient.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AuthorisationRequestInfoForClient.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models
+
+import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.InvitationStatus
+
+case class AuthorisationRequestInfoForClient(
+                                 agentName: String,
+                                 service: String,
+                                 status: InvitationStatus
+                                )
+
+object AuthorisationRequestInfoForClient {
+  implicit val format: Format[AuthorisationRequestInfoForClient] = Json.format[AuthorisationRequestInfoForClient]
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/common/ServiceData.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/common/ServiceData.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.models.common
 
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientType
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyErrors, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyErrors, AgentJourneyType}
 
 case class ServiceData(
                         serviceOption: Boolean = false,
@@ -27,8 +27,8 @@ case class ServiceData(
                         urlPart: Map[String, Set[String]],
                         clientTypes: Set[ClientType],
                         clientDetails: Seq[ClientDetailsConfiguration],
-                        journeyErrors: Map[JourneyType, JourneyErrors] = Map(
-                          JourneyType.AuthorisationRequest -> JourneyErrors(), 
-                          JourneyType.AgentCancelAuthorisation -> JourneyErrors()
+                        journeyErrors: Map[AgentJourneyType, JourneyErrors] = Map(
+                          AgentJourneyType.AuthorisationRequest -> JourneyErrors(),
+                          AgentJourneyType.AgentCancelAuthorisation -> JourneyErrors()
                         )
                       )

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourney.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourney.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, ClientStatus, KnownFactType}
 
-case class AgentJourney(journeyType: JourneyType,
+case class AgentJourney(journeyType: AgentJourneyType,
                         clientType: Option[String] = None,
                         clientService: Option[String] = None,
                         clientId: Option[String] = None,
@@ -43,15 +43,15 @@ case class AgentJourney(journeyType: JourneyType,
 
   def getKnownFactType: KnownFactType = clientDetailsResponse.flatMap(_.knownFactType)getOrElse(throw new RuntimeException("known fact is not defined"))
 
-  def getExitType(journeyType: JourneyType, clientDetails: ClientDetailsResponse, supportedAgentRoles: Seq[String] = Seq.empty): Option[JourneyExitType] = journeyType match
-    case JourneyType.AuthorisationRequest => clientDetails match {
+  def getExitType(journeyType: AgentJourneyType, clientDetails: ClientDetailsResponse, supportedAgentRoles: Seq[String] = Seq.empty): Option[JourneyExitType] = journeyType match
+    case AgentJourneyType.AuthorisationRequest => clientDetails match {
       case ClientDetailsResponse(_, Some(ClientStatus.Insolvent), _, _, _, _, _) => Some(JourneyExitType.ClientStatusInsolvent)
       case ClientDetailsResponse(_, Some(_), _, _, _, _, _) => Some(JourneyExitType.ClientStatusInvalid)
       case ClientDetailsResponse(_, None, _, _, _, true, _) => Some(JourneyExitType.ClientAlreadyInvited)
       case ClientDetailsResponse(_, None, _, _, _, false, Some(service)) if supportedAgentRoles.isEmpty && service == clientService.get => Some(JourneyExitType.AuthorisationAlreadyExists)
       case ClientDetailsResponse(_, None, _, _, _, false, _) => None
     }
-    case JourneyType.AgentCancelAuthorisation => clientDetails match {
+    case AgentJourneyType.AgentCancelAuthorisation => clientDetails match {
       case ClientDetailsResponse(_, _, _, _, _, _, Some(service)) if service == clientService.get || supportedAgentRoles.contains(service) => None
       case ClientDetailsResponse(_, _, _, _, _, _, Some(_)) => Some(JourneyExitType.NoAuthorisationExists)
       case ClientDetailsResponse(_, _, _, _, _, _, None) => Some(JourneyExitType.NoAuthorisationExists)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyType.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyType.scala
@@ -17,30 +17,29 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey
 
 import play.api.libs.json.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.inverseMapping
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.inverseMapping
 
-enum JourneyType:
-  case AuthorisationRequest, AgentCancelAuthorisation, ClientResponse
+enum AgentJourneyType:
+  case AuthorisationRequest, AgentCancelAuthorisation
 
   override def toString: String = inverseMapping(this)
 
-object JourneyType:
-  val mapping: Map[String, JourneyType] = Map(
+object AgentJourneyType:
+  val mapping: Map[String, AgentJourneyType] = Map(
     "authorisation-request" -> AuthorisationRequest,
-    "agent-cancel-authorisation" -> AgentCancelAuthorisation,
-    "client-response" -> ClientResponse
+    "agent-cancel-authorisation" -> AgentCancelAuthorisation
   )
-  val inverseMapping: Map[JourneyType, String] = mapping.map(_.swap)
+  val inverseMapping: Map[AgentJourneyType, String] = mapping.map(_.swap)
 
-  implicit val journeyTypeReads: Reads[JourneyType] = Reads[JourneyType] { json =>
+  implicit val journeyTypeReads: Reads[AgentJourneyType] = Reads[AgentJourneyType] { json =>
     json.validate[String].flatMap(string => mapping
       .get(string).map(JsSuccess(_))
       .getOrElse(JsError("Invalid JourneyType"))
     )
   }
 
-  implicit val journeyTypeWrites: Writes[JourneyType] = Writes[JourneyType] { journeyType =>
+  implicit val journeyTypeWrites: Writes[AgentJourneyType] = Writes[AgentJourneyType] { journeyType =>
     JsString(inverseMapping(journeyType))
   }
 
-  implicit val journeyTypeFormat: Format[JourneyType] = Format(journeyTypeReads, journeyTypeWrites)
+  implicit val journeyTypeFormat: Format[AgentJourneyType] = Format(journeyTypeReads, journeyTypeWrites)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{ClientType, E
 import java.time.Instant
 
 case class ClientJourney(
-                          journeyType: JourneyType,
+                          journeyType: String,
                           consent: Option[Boolean] = None,
                           invitationId: Option[String] = None,
                           serviceKey: Option[String] = None,
@@ -30,7 +30,8 @@ case class ClientJourney(
                           status: Option[InvitationStatus] = None,
                           lastModifiedDate: Option[Instant] = None,
                           clientType: Option[ClientType] = None,
-                          existingMainAgent: Option[ExistingMainAgent] = None
+                          existingMainAgent: Option[ExistingMainAgent] = None,
+                          journeyComplete: Option[String] = None
                         ) {
   def getAgentName: String = agentName.getOrElse(throw new RuntimeException("Agent Name is missing"))
   def getInvitationId: String = invitationId.getOrElse(throw new RuntimeException("Invitation Id is missing"))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.services
 
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentDetails, AuthorisationRequestInfo, ClientDetailsResponse}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentDetails, AuthorisationRequestInfo, AuthorisationRequestInfoForClient, ClientDetailsResponse}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyRequest, ClientJourneyRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
@@ -43,6 +43,10 @@ class AgentClientRelationshipsService @Inject()(agentClientRelationshipsConnecto
 
   def getAuthorisationRequest(invitationId: String)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[Option[AuthorisationRequestInfo]] = {
     agentClientRelationshipsConnector.getAuthorisationRequest(invitationId)
+  }
+
+  def getAuthorisationRequestForClient(invitationId: String)(implicit hc: HeaderCarrier, request: ClientJourneyRequest[?]): Future[Option[AuthorisationRequestInfoForClient]] = {
+    agentClientRelationshipsConnector.getAuthorisationRequestForClient(invitationId)
   }
 
   def getAgentDetails()(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[Option[AgentDetails]] = {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentJourneyService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentJourneyService.scala
@@ -33,11 +33,11 @@ class AgentJourneyService @Inject()(val journeyRepository: JourneyRepository,
 
   override val dataKey: DataKey[AgentJourney] = DataKey("AgentJourneySessionData")
   
-  def newJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
+  def newJourney(journeyType: AgentJourneyType): AgentJourney = AgentJourney(
     journeyType = journeyType
   )
 
-  def nextPageUrl(journeyType: JourneyType)(implicit request: Request[Any]): Future[String] = {
+  def nextPageUrl(journeyType: AgentJourneyType)(implicit request: Request[Any]): Future[String] = {
     for {
       journey <- getJourney()
     } yield journey match {
@@ -50,7 +50,7 @@ class AgentJourneyService @Inject()(val journeyRepository: JourneyRepository,
         else if (journey.clientDetailsResponse.get.knownFactType.nonEmpty && journey.knownFact.isEmpty) routes.EnterClientFactController.show(journeyType).url
         else if (journey.clientConfirmed.isEmpty) routes.ConfirmClientController.show(journeyType).url
         else if (journey.clientConfirmed.contains(false)) routes.StartJourneyController.startJourney(journeyType).url
-        else if (journeyType == JourneyType.AuthorisationRequest && serviceConfig.supportsAgentRoles(journey.getService) && journey.agentType.isEmpty) routes.SelectAgentRoleController.show(journeyType).url
+        else if (journeyType == AgentJourneyType.AuthorisationRequest && serviceConfig.supportsAgentRoles(journey.getService) && journey.agentType.isEmpty) routes.SelectAgentRoleController.show(journeyType).url
         else if (journey.getExitType(journeyType, journey.getClientDetailsResponse, serviceConfig.getSupportedAgentRoles(journey.getService)).nonEmpty) routes.JourneyExitController.show(journeyType, journey.getExitType(journeyType, journey.getClientDetailsResponse, serviceConfig.getSupportedAgentRoles(journey.getService)).get).url
         else routes.CheckYourAnswersController.show(journeyType).url
       }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.services
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientType.{business, personal, trust}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.{ClientDetailsConfiguration, ServiceData}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyErrors, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyErrors, JourneyExitType, AgentJourneyType}
 
 import javax.inject.{Inject, Singleton}
 import scala.collection.immutable.ListMap
@@ -58,7 +58,7 @@ class ClientServiceConfigurationService @Inject() extends ServiceConstants {
     case _ => clientService
   } else ""
 
-  def getNotFoundError(journeyType: JourneyType, clientService: String): JourneyExitType = services(clientService).journeyErrors(journeyType).notFound
+  def getNotFoundError(journeyType: AgentJourneyType, clientService: String): JourneyExitType = services(clientService).journeyErrors(journeyType).notFound
 
   def supportsAgentRoles(clientService: String): Boolean =  services(clientService).supportedAgentRoles.size > 1
 
@@ -95,10 +95,10 @@ class ClientServiceConfigurationService @Inject() extends ServiceConstants {
         )
       ),
       journeyErrors = Map(
-        JourneyType.AuthorisationRequest -> JourneyErrors(
+        AgentJourneyType.AuthorisationRequest -> JourneyErrors(
           notFound = JourneyExitType.NotRegistered
         ),
-        JourneyType.AgentCancelAuthorisation -> JourneyErrors()
+        AgentJourneyType.AgentCancelAuthorisation -> JourneyErrors()
       )
     ),
     HMRCMTDITSUPP -> ServiceData(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPage.scala.html
@@ -34,7 +34,6 @@
 @serviceKey = @{journey.getServiceKey}
 @agentName = @{journey.getAgentName}
 @choice = @{journey.getConsent}
-@invitationId = @{journey.getInvitationId}
 @pageTitle = @{
     messages(s"$key.title")
 }
@@ -50,7 +49,8 @@
         rows = Seq(
             SummaryListRow(
                 key = Key(
-                    content = Text(messages(s"$key.$serviceKey.question", agentName))
+                    content = Text(messages(s"$key.$serviceKey.question", agentName)),
+                    classes = "govuk-!-width-one-half"
                 ),
                 value = Value(
                     content = Text(messages(s"$key.$choice"))
@@ -58,7 +58,7 @@
                 actions = Some(Actions(
                     items = Seq(
                         ActionItem(
-                            href = s"/agent-client-relationships/authorisation-response/confirm-consent/$invitationId",
+                            href = routes.ConfirmConsentController.show.url,
                             content = Text(messages(s"$key.change")),
                             visuallyHiddenText = Some(messages(s"$key.$serviceKey.question"))
                         )

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPage.scala.html
@@ -1,0 +1,68 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.Layout
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AgentCancelAuthorisationResponse
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourneyRequest
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AuthorisationRequestInfoForClient
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{Accepted, Rejected, PartialAuth}
+@this(
+        layout: Layout,
+        govukPanel: GovukPanel
+)
+
+@(authorisationRequestInfo: AuthorisationRequestInfoForClient)(implicit request: ClientJourneyRequest[?], messages: Messages, appConfig: AppConfig)
+
+@key = @{"clientConfirmation"}
+@decisionKey = @{authorisationRequestInfo.status match {
+    case Accepted | PartialAuth => "accepted"
+    case Rejected => "rejected"
+    case status => throw new RuntimeException(s"Cannot confirm client completion of accept/reject when status is $status")
+}}
+@agentName = @{authorisationRequestInfo.agentName}
+@serviceKey = @{authorisationRequestInfo.service}
+@pageTitle = @{
+    messages(s"$key.$decisionKey.h1", agentName)
+}
+
+@layout(
+    pageTitle = pageTitle,
+    serviceName = Some(messages("service.name.clients")),
+    suppressBackLink = true
+) {
+
+    @govukPanel(Panel(title = Text(pageTitle)))
+
+    @if(messages.isDefinedAt(s"$key.$decisionKey.h2")) {
+        <h2 class="govuk-heading-m">@messages(s"$key.$decisionKey.h2")</h2>
+    }
+
+    <p class="govuk-body">@messages(s"$key.$decisionKey.$serviceKey.p1", agentName)</p>
+
+    <h2 class="govuk-heading-m">@messages(s"$key.section2.h2")</h2>
+    <p class="govuk-body">@Html(messages(s"$key.section2.p1", appConfig.acmExternalUrl))</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>@messages(s"$key.section2.li1")</li>
+        <li>@messages(s"$key.section2.li2")</li>
+        <li>@messages(s"$key.section2.li3")</li>
+    </ul>
+    <p class="govuk-body">
+        <a class="govuk-link" href="@{routes.SignOutController.signOut.url}">@messages(s"$key.section2.signOutLink")</a>
+    </p>
+    
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPage.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.SubmitButton
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyRequest
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.AuthorisationRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientConfirmationFieldName
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePage.scala.html
@@ -20,7 +20,7 @@
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AuthorisationRequestInfo
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.DisplayDate
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType
 
 @this(
         layout: Layout,
@@ -68,7 +68,7 @@
     </ul>
 
     <p class="govuk-body">
-        <a href="@{routes.StartJourneyController.startJourney(JourneyType.AuthorisationRequest)}" class="govuk-link">@messages(s"$key.createAnother")</a>
+        <a href="@{routes.StartJourneyController.startJourney(AgentJourneyType.AuthorisationRequest)}" class="govuk-link">@messages(s"$key.createAnother")</a>
     </p>
 
     <p class="govuk-body">

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/JourneyExitPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/JourneyExitPage.scala.html
@@ -20,7 +20,7 @@
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.agentExitPartials._
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.SubmitButton
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyExitType, JourneyType, AgentJourneyRequest}
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{JourneyExitType, AgentJourneyType, AgentJourneyRequest}
 
 
 @this(
@@ -35,7 +35,7 @@
         clientAlreadyInvited: ClientAlreadyInvited
 )
 
-@(journeyType: JourneyType, exitType: JourneyExitType)(implicit request: AgentJourneyRequest[?], messages: Messages, appConfig: AppConfig)
+@(journeyType: AgentJourneyType, exitType: JourneyExitType)(implicit request: AgentJourneyRequest[?], messages: Messages, appConfig: AppConfig)
 @key = @{"journeyExit"}
 @pageTitle = @{messages(s"$key.$exitType.header")}
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePage.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.SubmitButton
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentRoleChangeType, AgentJourneyRequest}
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.AuthorisationRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.AgentRoleFieldName
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePage.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.SubmitButton
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyRequest
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.AuthorisationRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientServiceFieldName
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPage.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.components.SubmitButton
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyRequest
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.AuthorisationRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.ClientServiceFieldName
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val microservice = Project("agent-client-relationships-frontend", file(".")
     RoutesKeys.routesImport ++= Seq(
       "uk.gov.hmrc.play.bootstrap.binders.RedirectUrl",
       "uk.gov.hmrc.agentclientrelationshipsfrontend.binders.UrlBinders._",
-      "uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType",
+      "uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType",
       "uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyExitType",
       "uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType"
     )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -17,42 +17,6 @@ GET         /cannot-confirm-identity                                            
 GET         /iv-timed-out                                                               uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.ivTimedOut(continueUrl: Option[RedirectUrl] ?= None)
 GET         /iv-locked-out                                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.ivLockedOut
 
-# Agent Journey URLs ----------------------------------------------------------------------------------------------------------
-GET        /:journeyType                                                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.StartJourneyController.startJourney(journeyType: JourneyType)
-
-GET        /:journeyType/client-type                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectClientTypeController.show(journeyType: JourneyType)
-POST       /:journeyType/client-type                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectClientTypeController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/select-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectServiceController.show(journeyType: JourneyType)
-POST       /:journeyType/select-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectServiceController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/refine-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ServiceRefinementController.show(journeyType: JourneyType)
-POST       /:journeyType/refine-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ServiceRefinementController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/client-identifier                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientIdController.show(journeyType: JourneyType)
-POST       /:journeyType/client-identifier                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientIdController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/client-fact                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientFactController.show(journeyType: JourneyType)
-POST       /:journeyType/client-fact                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientFactController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/confirm-client                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ConfirmClientController.show(journeyType: JourneyType)
-POST       /:journeyType/confirm-client                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ConfirmClientController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/agent-role                                                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectAgentRoleController.show(journeyType: JourneyType)
-POST       /:journeyType/agent-role                                                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectAgentRoleController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/confirm                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.CheckYourAnswersController.show(journeyType: JourneyType)
-POST       /:journeyType/confirm                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.CheckYourAnswersController.onSubmit(journeyType: JourneyType)
-
-GET        /:journeyType/confirmation                                                   uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ConfirmationController.show(journeyType: JourneyType)
-
-GET        /:journeyType/exit/:exitType                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.JourneyExitController.show(journeyType: JourneyType, exitType: JourneyExitType)
-
-
-# Fast Track URLs ----------------------------------------------------------------------------------------------------------
-+ nocsrf
-POST        /agents/fast-track                                                          uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AgentFastTrackController.agentFastTrack
-
 # Client Journey URLs ----------------------------------------------------------------------------------------------------------
 
 GET        /appoint-someone-to-deal-with-HMRC-for-you/:uid/:normalizedAgentName/:taxService             uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.StartController.show(uid: String, normalizedAgentName: String, taxService: String)
@@ -68,3 +32,41 @@ POST       /authorisation-response/confirm-consent                              
 
 GET        /authorisation-response/check-answer                                         uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.CheckYourAnswerController.show
 POST       /authorisation-response/check-answer                                         uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.CheckYourAnswerController.submit
+
+GET        /authorisation-response/confirmation                                         uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConfirmationController.show
+
+# Agent Journey URLs ----------------------------------------------------------------------------------------------------------
+GET        /:journeyType                                                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.StartJourneyController.startJourney(journeyType: AgentJourneyType)
+
+GET        /:journeyType/client-type                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectClientTypeController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/client-type                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectClientTypeController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/select-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectServiceController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/select-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectServiceController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/refine-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ServiceRefinementController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/refine-service                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ServiceRefinementController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/client-identifier                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientIdController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/client-identifier                                              uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientIdController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/client-fact                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientFactController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/client-fact                                                    uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.EnterClientFactController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/confirm-client                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ConfirmClientController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/confirm-client                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ConfirmClientController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/agent-role                                                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectAgentRoleController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/agent-role                                                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.SelectAgentRoleController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/confirm                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.CheckYourAnswersController.show(journeyType: AgentJourneyType)
+POST       /:journeyType/confirm                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.CheckYourAnswersController.onSubmit(journeyType: AgentJourneyType)
+
+GET        /:journeyType/confirmation                                                   uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.ConfirmationController.show(journeyType: AgentJourneyType)
+
+GET        /:journeyType/exit/:exitType                                                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.JourneyExitController.show(journeyType: AgentJourneyType, exitType: JourneyExitType)
+
+
+# Fast Track URLs ----------------------------------------------------------------------------------------------------------
++ nocsrf
+POST        /agents/fast-track                                                          uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AgentFastTrackController.agentFastTrack

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,7 +105,7 @@ timeoutDialog {
 
 mongodb {
   uri = "mongodb://localhost:27017/agent-client-relationships-frontend"
-  session.expireAfterSeconds = 3600 
+  session.expireAfterSeconds = 3600
   # 1 hour
 }
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -26,7 +26,7 @@
 
     <logger name="uk.gov" level="INFO"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="application" level="TRACE"/>
 
     <logger name="connector" level="TRACE">
         <appender-ref ref="STDOUT"/>

--- a/conf/messages
+++ b/conf/messages
@@ -740,6 +740,44 @@ checkYourAnswer.acceptAndSend.button=Accept and send
 checkYourAnswer.change=Change
 
 # ________________________________________________________________________________
+# Client confirmation page
+# ________________________________________________________________________________
+
+clientConfirmation.accepted.h1=You have authorised {0}
+clientConfirmation.accepted.h2=What this means
+clientConfirmation.accepted.HMRC-MTD-IT.p1={0} is now your main agent for Making Tax Digital for Income Tax.
+clientConfirmation.accepted.HMRC-MTD-IT-SUPP.p1={0} is now your supporting agent for Making Tax Digital for Income Tax.
+clientConfirmation.accepted.PERSONAL-INCOME-RECORD.p1={0} is now your agent for Income Record Viewer.
+clientConfirmation.accepted.HMRC-MTD-VAT.p1={0} is now your agent for VAT.
+clientConfirmation.accepted.HMRC-CGT-PD.p1={0} is now your agent for Capital Gains Tax on UK property account.
+clientConfirmation.accepted.HMRC-PPT-ORG.p1={0} is now your agent for Plastic Packaging Tax.
+clientConfirmation.accepted.HMRC-CBC-ORG.p1={0} is now your agent for Country-by-country reporting.
+clientConfirmation.accepted.HMRC-CBC-NONUK-ORG.p1={0} is now your agent for Country-by-country reporting.
+clientConfirmation.accepted.HMRC-PILLAR2-ORG.p1={0} is now your agent for Pillar 2 Top-up Taxes.
+clientConfirmation.accepted.HMRC-TERS-ORG.p1={0} is now your agent for Trusts and Estates.
+clientConfirmation.accepted.HMRC-TERSNT-ORG.p1={0} is now your agent for Trusts and Estates.
+
+clientConfirmation.section2.h2=What you can do next
+clientConfirmation.section2.p1=Go to <a href={0} class="govuk-link">Manage who can deal with HMRC for you</a> to:
+clientConfirmation.section2.li1=view any agent requests you need to respond to
+clientConfirmation.section2.li2=check who’s currently allowed to deal with HMRC for you
+clientConfirmation.section2.li3=remove consent if you no longer want an agent to act for you
+clientConfirmation.section2.signOutLink=Finish and sign out
+
+clientConfirmation.rejected.h1=You declined a request from {0}
+clientConfirmation.rejected.HMRC-MTD-IT.p1=You have not given permission for {0} to manage your Making Tax Digital for Income Tax.
+clientConfirmation.rejected.HMRC-MTD-IT-SUPP.p1=You have not given permission for {0} to manage your Making Tax Digital for Income Tax.
+clientConfirmation.rejected.PERSONAL-INCOME-RECORD.p1=You have not given permission for {0} to view your personal income record.
+clientConfirmation.rejected.HMRC-MTD-VAT.p1=You have not given permission for {0} to manage your VAT.
+clientConfirmation.rejected.HMRC-CGT-PD.p1=You have not given permission for {0} to manage your Capital Gains Tax on UK property account.
+clientConfirmation.rejected.HMRC-PPT-ORG.p1=You have not given permission for {0} to manage your Plastic Packaging Tax.
+clientConfirmation.rejected.HMRC-CBC-ORG.p1=You have not given permission for {0} to manage your Country-by-country reporting.
+clientConfirmation.rejected.HMRC-CBC-NONUK-ORG.p1=You have not given permission for {0} to manage your Country-by-country reporting.
+clientConfirmation.rejected.HMRC-PILLAR2-ORG.p1=You have not given permission for {0} to manage your Pillar 2 Top-up Taxes.
+clientConfirmation.rejected.HMRC-TERS-ORG.p1=You have not given permission for {0} to manage a trust or an estate.
+clientConfirmation.rejected.HMRC-TERSNT-ORG.p1=You have not given permission for {0} to manage a trust or an estate.
+
+# ________________________________________________________________________________
 # Unauthorised exit partials
 # ________________________________________________________________________________
 unauthorisedExit.agent-suspended.header=You cannot appoint this tax agent

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnectorISpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.connectors
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.invitationLink.ValidateLinkPartsResponse
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyRequest, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, ClientStatus, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, ComponentSpecHelper}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
@@ -61,7 +61,7 @@ class AgentClientRelationshipsConnectorISpec extends ComponentSpecHelper with Ag
 
   private val basicClientDetails = ClientDetailsResponse(testName, None, None, Seq(testPostCode), Some(KnownFactType.PostalCode), false, None)
   private val basicJourney: AgentJourney = AgentJourney(
-    journeyType = JourneyType.AgentCancelAuthorisation,
+    journeyType = AgentJourneyType.AgentCancelAuthorisation,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
     clientId = Some(testClientId),

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentFastTrackControllerSpec.scala
@@ -23,14 +23,14 @@ import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes as journeyRoutes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes as fastTrackRoutes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.testOnly.routes as testRoutes
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentFastTrackRequest, ClientDetailsResponse, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientServiceConfigurationService, AgentJourneyService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
 
 class AgentFastTrackControllerSpec extends ComponentSpecHelper with AuthStubs with AgentClientRelationshipStub with ScalaFutures {
 
-  lazy val journeyType: JourneyType = JourneyType.AuthorisationRequest
+  lazy val journeyType: AgentJourneyType = AgentJourneyType.AuthorisationRequest
 
   def getClientDetailsUrl(service: String, clientId: String) = s"/agent-client-relationships/client/$service/details/$clientId"
 
@@ -175,8 +175,8 @@ class AgentFastTrackControllerSpec extends ComponentSpecHelper with AuthStubs wi
      "knownFact" -> agentFastTrackRequest.knownFact.fold(Seq.empty)(Seq(_))
    )
 
-   def toJourney(agentFastTrackRequest: AgentFastTrackRequest,clientDetailsResponse: Option[ClientDetailsResponse], journeyType: JourneyType = journeyType): AgentJourney =
-     journeyService.newJourney(JourneyType.AuthorisationRequest)
+   def toJourney(agentFastTrackRequest: AgentFastTrackRequest,clientDetailsResponse: Option[ClientDetailsResponse], journeyType: AgentJourneyType = journeyType): AgentJourney =
+     journeyService.newJourney(AgentJourneyType.AuthorisationRequest)
        .copy(
          clientService = Some(agentFastTrackRequest.service),
          clientId = Some(agentFastTrackRequest.clientIdentifier),

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitControllerISpec.scala
@@ -22,7 +22,6 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourney
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
@@ -47,7 +46,7 @@ class ClientExitControllerISpec extends ComponentSpecHelper with AuthStubs {
   val validateInvitationUrl = s"/agent-client-relationships/client/validate-invitation"
 
   def journeyModel(status: Option[InvitationStatus]): ClientJourney = ClientJourney(
-    ClientResponse,
+    "authorisation-response",
     consent = Some(true),
     serviceKey = Some("HMRC-MTD-IT"),
     invitationId = Some("ABC123"),

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentControllerISpec.scala
@@ -20,7 +20,6 @@ import play.api.http.Status.*
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{ExistingMainAgent, Pending}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourney
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
 
@@ -31,7 +30,7 @@ class ConfirmConsentControllerISpec extends ComponentSpecHelper with AuthStubs w
   val journeyService: ClientJourneyService = app.injector.instanceOf[ClientJourneyService]
 
   val journeyModel: ClientJourney = ClientJourney(
-    ClientResponse,
+    "authorisation-response",
     consent = Some(true),
     serviceKey = Some("HMRC-MTD-IT"),
     invitationId = Some("ABC123"),

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationControllerISpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import play.api.http.Status.OK
+import play.api.libs.json.{JsObject, Json}
+import play.api.test.Helpers.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{Accepted, InvitationStatus, PartialAuth, Rejected}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourney
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientJourneyService
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
+
+class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
+
+  val testInvitationId: String = "AB1234567890"
+
+  def getAuthorisationRequestUrl = s"/agent-client-relationships/client/authorisation-request-info/$testInvitationId"
+
+  def getAgentDetailsUrl = s"/agent-client-relationships/agent/$testArn/details"
+
+  val agentName: String = "ABC Accountants"
+  val testEmail: String = "abc@example.com"
+
+  val testCreateAuthorisationRequestResponseJson: JsObject = Json.obj(
+    "invitationId" -> testInvitationId
+  )
+
+  def testGetAgentDetailsResponse: JsObject = Json.obj(
+    "agencyDetails" -> Json.obj(
+      "agencyName" -> agentName,
+      "agencyEmail" -> testEmail
+    )
+  )
+
+  def testGetAuthorisationRequestInfoResponse(service: String, status: InvitationStatus): JsObject = Json.obj(
+    "agentName" -> agentName,
+    "service" -> service,
+    "status" -> status.toString
+  )
+
+  private val completeJourney: ClientJourney = ClientJourney(
+    "authorisation-response",
+    journeyComplete = Some(testInvitationId)
+  )
+
+  val journeyService: ClientJourneyService = app.injector.instanceOf[ClientJourneyService]
+
+  override def beforeEach(): Unit = {
+    await(journeyService.deleteAllAnswersInSession(request))
+    super.beforeEach()
+  }
+
+  "GET /authorisation-response/confirmation" should {
+    "redirect to MYTA when no journey session present" in {
+      authoriseAsClient()
+      val result = get(routes.ConfirmationController.show.url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe "http://localhost:9568/manage-your-tax-agents"
+    }
+    List(Accepted, Rejected, PartialAuth).foreach(decision => s"display the confirmation page for ${decision.toString} when the invitation id is in journeyComplete" in {
+      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+      stubGet(getAuthorisationRequestUrl, OK, testGetAuthorisationRequestInfoResponse("HMRC-MTD-IT", decision).toString())
+      await(journeyService.saveJourney(completeJourney))
+      val result = get(routes.ConfirmationController.show.url)
+      result.status shouldBe OK
+    })
+  }
+
+}

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationControllerISpec.scala
@@ -22,7 +22,6 @@ import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourney
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientJourneyService, ClientServiceConfigurationService}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubPost
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
@@ -73,7 +72,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
     
     "Redirect correctly to NotFound exit page" in {
       authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = ClientResponse)))
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
       stubPost(validateInvitationUrl, NOT_FOUND, "")
       val result = get(routes.ConsentInformationController.show(testUid,"income-tax").url)
       result.status shouldBe SEE_OTHER
@@ -81,7 +80,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
 
     "Redirect correctly to agent suspended exit page" in {
       authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = ClientResponse)))
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
       stubPost(validateInvitationUrl, FORBIDDEN, "")
       val result = get(routes.ConsentInformationController.show(testUid, "income-tax").url)
       result.status shouldBe SEE_OTHER
@@ -91,14 +90,14 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
     taxServices.keySet.foreach { taxService =>
       s"Display consent information page for $taxService" in {
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = ClientResponse)))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService)).toString())
         val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
         result.status shouldBe OK
       }
       s"Redirect correctly to expired exit page for $taxService" in {
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = ClientResponse)))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Expired").toString())
         val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER
@@ -106,7 +105,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
       }
       s"Redirect correctly to cancelled exit page for $taxService" in {
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = ClientResponse)))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Cancelled").toString())
         val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER
@@ -114,7 +113,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
       }
       s"Redirect correctly to already responded exit page for $taxService" in {
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = ClientResponse)))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Accepted").toString())
         val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/AgentJourneyExitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/AgentJourneyExitControllerISpec.scala
@@ -19,21 +19,21 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class AgentJourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs {
 
   private val authorisationRequestJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
     clientId = Some("AB123"),
     clientDetailsResponse = Some(ClientDetailsResponse("Test Name", None, None, Seq("AA11AA"), Some(KnownFactType.PostalCode), false, None))
   )
   private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(
-    JourneyType.AgentCancelAuthorisation,
+    AgentJourneyType.AgentCancelAuthorisation,
     clientType = Some("personal"),
     clientService = Some("HMRC-MTD-IT"),
     clientId = Some("AB123"),

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmClientControllerISpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, ClientStatus, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
@@ -29,7 +29,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   val testCgtRef: String = "XMCGTP123456789"
   val testPostcode: String = "AA11AA"
 
-  def noAuthJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
+  def noAuthJourney(journeyType: AgentJourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -38,7 +38,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def noAuthJourneyWithSupportedRoles(journeyType: JourneyType): AgentJourney = AgentJourney(
+  def noAuthJourneyWithSupportedRoles(journeyType: AgentJourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-MTD-IT"),
@@ -47,7 +47,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
     Some(testPostcode)
   )
 
-  def alreadyAuthJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
+  def alreadyAuthJourney(journeyType: AgentJourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-CGT-PD"),
@@ -57,7 +57,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   )
 
   def existingPendingRequestJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     Some("personal"),
     Some("HMRC-CGT-PD"),
     Some(testCgtRef),
@@ -66,7 +66,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   )
 
   def clientInsolventJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     Some("personal"),
     Some("HMRC-CGT-PD"),
     Some(testCgtRef),
@@ -75,7 +75,7 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   )
 
   def clientStatusInvalidJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     Some("personal"),
     Some("HMRC-CGT-PD"),
     Some(testCgtRef),
@@ -93,12 +93,12 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   "GET /authorisation-request/confirm-client" should {
     "redirect to enter client id when it is missing" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"), clientService = Some("HMRC-MTD-IT"))))
-      val result = get(routes.ConfirmClientController.show(JourneyType.AuthorisationRequest).url)
+      await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("personal"), clientService = Some("HMRC-MTD-IT"))))
+      val result = get(routes.ConfirmClientController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.EnterClientIdController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.EnterClientIdController.show(AgentJourneyType.AuthorisationRequest).url
     }
-    List(noAuthJourney(JourneyType.AuthorisationRequest), noAuthJourney(JourneyType.AgentCancelAuthorisation))
+    List(noAuthJourney(AgentJourneyType.AuthorisationRequest), noAuthJourney(AgentJourneyType.AgentCancelAuthorisation))
       .foreach(j => s"display the confirm client page on ${j.journeyType.toString} journey" in {
         authoriseAsAgent()
         await(journeyService.saveJourney(j))
@@ -110,87 +110,87 @@ class ConfirmClientControllerISpec extends ComponentSpecHelper with AuthStubs {
   "POST /authorisation-request/confirm-client" should {
     "redirect to select agent role page when service has supported roles and client is confirmed" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(noAuthJourneyWithSupportedRoles(JourneyType.AuthorisationRequest)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(noAuthJourneyWithSupportedRoles(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectAgentRoleController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.SelectAgentRoleController.show(AgentJourneyType.AuthorisationRequest).url
     }
     "redirect to check your answers after confirming client on authorisation-request journey" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(noAuthJourney(JourneyType.AuthorisationRequest)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(noAuthJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.CheckYourAnswersController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.CheckYourAnswersController.show(AgentJourneyType.AuthorisationRequest).url
     }
 
     "redirect to authorisation-exists exit page when confirming client with existing authorisation" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(alreadyAuthJourney(JourneyType.AuthorisationRequest)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(alreadyAuthJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.JourneyExitController.show(JourneyType.AuthorisationRequest, JourneyExitType.AuthorisationAlreadyExists).url
+      result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AuthorisationRequest, JourneyExitType.AuthorisationAlreadyExists).url
     }
 
     "redirect to check your answers page when confirming client to deAuth with existing authorisation" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(alreadyAuthJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      await(journeyService.saveJourney(alreadyAuthJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.CheckYourAnswersController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.CheckYourAnswersController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
 
     "redirect to not-authorised exist page when confirming client to deAuth with no existing authorisation" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(noAuthJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      await(journeyService.saveJourney(noAuthJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.JourneyExitController.show(JourneyType.AgentCancelAuthorisation, JourneyExitType.NoAuthorisationExists).url
+      result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AgentCancelAuthorisation, JourneyExitType.NoAuthorisationExists).url
     }
 
     "redirect to client-insolvent page when client is insolvent" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(clientInsolventJourney))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.JourneyExitController.show(JourneyType.AuthorisationRequest, JourneyExitType.ClientStatusInsolvent).url
+      result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AuthorisationRequest, JourneyExitType.ClientStatusInsolvent).url
     }
 
     "redirect to client-status-invalid page when client status is invalid" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(clientStatusInvalidJourney))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "confirmClient" -> Seq("true")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.JourneyExitController.show(JourneyType.AuthorisationRequest, JourneyExitType.ClientStatusInvalid).url
+      result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AuthorisationRequest, JourneyExitType.ClientStatusInvalid).url
     }
 
     "redirect to start again when not confirming client" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(noAuthJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      await(journeyService.saveJourney(noAuthJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "confirmClient" -> Seq("false")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.StartJourneyController.startJourney(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.StartJourneyController.startJourney(AgentJourneyType.AgentCancelAuthorisation).url
     }
 
     "show an error when no selection is made" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(noAuthJourney(JourneyType.AuthorisationRequest)))
-      val result = post(routes.ConfirmClientController.onSubmit(JourneyType.AuthorisationRequest).url)("")
+      await(journeyService.saveJourney(noAuthJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.ConfirmClientController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ConfirmationControllerISpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.http.Status.OK
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
@@ -64,14 +64,14 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
   )
 
   private val completeCancellationJourney: AgentJourney = AgentJourney(
-    JourneyType.AgentCancelAuthorisation,
+    AgentJourneyType.AgentCancelAuthorisation,
     journeyComplete = Some("2024-12-25"),
     confirmationClientName = Some(testClientName),
     confirmationService = Some("HMRC-MTD-IT")
   )
 
   private val completeCreateAuthorisationRequestJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     journeyComplete = Some(testInvitationId)
   )
 
@@ -85,7 +85,7 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
   "GET /authorisation-request/confirmation" should {
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
-      val result = get(routes.ConfirmationController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.ConfirmationController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
     }
@@ -93,7 +93,7 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
       authoriseAsAgent()
       stubGet(getAuthorisationRequestUrl, OK, testGetAuthorisationRequestInfoResponse("HMRC-MTD-IT").toString())
       await(journeyService.saveJourney(completeCreateAuthorisationRequestJourney))
-      val result = get(routes.ConfirmationController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.ConfirmationController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe OK
     }
   }
@@ -101,7 +101,7 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
   "GET /agent-cancel-authorisation/confirmation" should {
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
-      val result = get(routes.ConfirmationController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.ConfirmationController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
     }
@@ -109,7 +109,7 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
       authoriseAsAgent()
       stubGet(getAgentDetailsUrl, OK, testGetAgentDetailsResponse.toString())
       await(journeyService.saveJourney(completeCancellationJourney))
-      val result = get(routes.ConfirmationController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.ConfirmationController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe OK
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactControllerISpec.scala
@@ -20,7 +20,7 @@ import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.KnownFactType.PostalCode
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType, JourneyExitType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType, JourneyExitType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
@@ -30,7 +30,7 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   val testNino: String = "AB123456C"
   val testPostcode: String = "AA11AA"
 
-  def testItsaJourney(journeyType: JourneyType): AgentJourney = AgentJourney(
+  def testItsaJourney(journeyType: AgentJourneyType): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-MTD-IT"),
@@ -48,15 +48,15 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   "GET /authorisation-request/client-fact" should {
     "redirect to the journey start when previous answers are missing" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))))
-      val result = get(routes.EnterClientFactController.show(JourneyType.AuthorisationRequest).url)
+      await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("personal"))))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AuthorisationRequest).url
     }
     "display the client identifier page for ITSA" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AuthorisationRequest)))
-      val result = get(routes.EnterClientFactController.show(JourneyType.AuthorisationRequest).url)
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe OK
     }
   }
@@ -64,26 +64,26 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   "POST /authorisation-request/client-fact" should {
     "redirect to the next page after storing answer for ITSA" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AuthorisationRequest)))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ConfirmClientController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.ConfirmClientController.show(AgentJourneyType.AuthorisationRequest).url
     }
     "redirect to client-not-found when submitting a mismatching KF" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AuthorisationRequest)))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "postcode" -> Seq("ZZ1 1ZZ")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.JourneyExitController.show(JourneyType.AuthorisationRequest, JourneyExitType.NotFound).url
+      result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AuthorisationRequest, JourneyExitType.NotFound).url
     }
     "unset existing answers when submitting a new answer" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AuthorisationRequest).copy(knownFact = Some("ZZ1 1AA"), clientConfirmed = Some(true))))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest).copy(knownFact = Some("ZZ1 1AA"), clientConfirmed = Some(true))))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
       val updatedJourney = await(journeyService.getJourney(request))
@@ -91,8 +91,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
     }
     "leave existing answers intact when submitting the same answer" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AuthorisationRequest).copy(knownFact = Some(testPostcode), clientConfirmed = Some(true))))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest).copy(knownFact = Some(testPostcode), clientConfirmed = Some(true))))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
       val updatedJourney = await(journeyService.getJourney(request))
@@ -100,8 +100,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
     }
     "show an error when no selection is made" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AuthorisationRequest)))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AuthorisationRequest).url)("")
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }
@@ -109,15 +109,15 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   "GET /agent-cancel-authorisation/client-fact" should {
     "redirect to the journey start when previous answers are missing" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
-      val result = get(routes.EnterClientFactController.show(JourneyType.AgentCancelAuthorisation).url)
+      await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AgentCancelAuthorisation, clientType = None)))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
     "display the the client identifier page for ITSA" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = get(routes.EnterClientFactController.show(JourneyType.AgentCancelAuthorisation).url)
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe OK
     }
   }
@@ -125,26 +125,26 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
   "POST /agent-cancel-authorisation/client-fact" should {
     "redirect to the next page after storing answer for ITSA" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(body = Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(body = Map(
         "postcode" -> Seq(testPostcode)
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ConfirmClientController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.ConfirmClientController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
     "redirect to client-not-found when submitting a mismatching KF" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "postcode" -> Seq("ZZ1 1ZZ")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.JourneyExitController.show(JourneyType.AgentCancelAuthorisation, JourneyExitType.NotFound).url
+      result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AgentCancelAuthorisation, JourneyExitType.NotFound).url
     }
     "unset existing answers when submitting a new answer" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AgentCancelAuthorisation).copy(knownFact = Some("ZZ1 1AA"), clientConfirmed = Some(true))))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation).copy(knownFact = Some("ZZ1 1AA"), clientConfirmed = Some(true))))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
       val updatedJourney = await(journeyService.getJourney(request))
@@ -152,8 +152,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
     }
     "leave existing answers intact when submitting the same answer" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AgentCancelAuthorisation).copy(knownFact = Some(testPostcode), clientConfirmed = Some(true))))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation).copy(knownFact = Some(testPostcode), clientConfirmed = Some(true))))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "postcode" -> Seq(testPostcode)
       ))
       val updatedJourney = await(journeyService.getJourney(request))
@@ -161,8 +161,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
     }
     "show an error when no selection is made" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(testItsaJourney(JourneyType.AgentCancelAuthorisation)))
-      val result = post(routes.EnterClientFactController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(body = Map("postcode" -> Seq("")))
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(body = Map("postcode" -> Seq("")))
       result.status shouldBe BAD_REQUEST
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectAgentRoleControllerISpec.scala
@@ -19,14 +19,14 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class SelectAgentRoleControllerISpec extends ComponentSpecHelper with AuthStubs {
 
   val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
-  val journeyType: JourneyType = JourneyType.AuthorisationRequest // this controller is only used on AuthorisationRequest journeys
+  val journeyType: AgentJourneyType = AgentJourneyType.AuthorisationRequest // this controller is only used on AuthorisationRequest journeys
 
   override def beforeEach(): Unit = {
     await(journeyService.deleteAllAnswersInSession(request))

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectClientTypeControllerISpec.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class SelectClientTypeControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
 
@@ -38,7 +38,7 @@ class SelectClientTypeControllerISpec extends ComponentSpecHelper with AuthStubs
     "display the select client type page" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(authorisationRequestJourney))
-      val result = get(routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.SelectClientTypeController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe OK
     }
   }
@@ -47,16 +47,16 @@ class SelectClientTypeControllerISpec extends ComponentSpecHelper with AuthStubs
     Seq("personal", "business", "trust").foreach(clientType => s"redirect to the next page after storing $clientType as the answer" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(authorisationRequestJourney))
-      val result = post(routes.SelectClientTypeController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      val result = post(routes.SelectClientTypeController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "clientType" -> Seq(clientType)
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectServiceController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.SelectServiceController.show(AgentJourneyType.AuthorisationRequest).url
     })
     "show an error when no selection is made" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(authorisationRequestJourney))
-      val result = post(routes.SelectClientTypeController.onSubmit(JourneyType.AuthorisationRequest).url)("")
+      val result = post(routes.SelectClientTypeController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }
@@ -65,7 +65,7 @@ class SelectClientTypeControllerISpec extends ComponentSpecHelper with AuthStubs
     "display the select client type page" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(agentCancelAuthorisationJourney))
-      val result = get(routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.SelectClientTypeController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe OK
     }
   }
@@ -74,16 +74,16 @@ class SelectClientTypeControllerISpec extends ComponentSpecHelper with AuthStubs
     Seq("personal", "business", "trust").foreach(clientType => s"redirect to the next page after storing $clientType as the answer" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(agentCancelAuthorisationJourney))
-      val result = post(routes.SelectClientTypeController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      val result = post(routes.SelectClientTypeController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "clientType" -> Seq("personal")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectServiceController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.SelectServiceController.show(AgentJourneyType.AgentCancelAuthorisation).url
     })
     "show an error when no selection is made" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(agentCancelAuthorisationJourney))
-      val result = post(routes.SelectClientTypeController.onSubmit(JourneyType.AgentCancelAuthorisation).url)("")
+      val result = post(routes.SelectClientTypeController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/SelectServiceControllerISpec.scala
@@ -18,18 +18,18 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyState, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
 
-  private val personalAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("personal"))
-  private val businessAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("business"))
-  private val trustAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"))
-  private val personalAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("personal"))
-  private val businessAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("business"))
-  private val trustAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation, clientType = Some("trust"))
+  private val personalAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("personal"))
+  private val businessAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("business"))
+  private val trustAuthorisationRequestJourney: AgentJourney = AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("trust"))
+  private val personalAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation, clientType = Some("personal"))
+  private val businessAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation, clientType = Some("business"))
+  private val trustAgentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation, clientType = Some("trust"))
 
   private val optionsForPersonal: Seq[String] = Seq("HMRC-MTD-IT", "PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-CGT-PD", "HMRC-PPT-ORG")
   private val optionsForBusiness: Seq[String] = Seq("HMRC-MTD-VAT", "HMRC-PPT-ORG", "HMRC-CBC-ORG", "HMRC-PILLAR2-ORG")
@@ -64,21 +64,21 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
   "GET /authorisation-request/select-service" should {
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
-      val result = get(routes.SelectServiceController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.SelectServiceController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
     }
     "redirect to the journey start when no client type present" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = None)))
-      val result = get(routes.SelectServiceController.show(JourneyType.AuthorisationRequest).url)
+      await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = None)))
+      val result = get(routes.SelectServiceController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AuthorisationRequest).url
     }
     allClientTypeAuthJourneys.foreach(j => s"display the select service page for ${j.getClientType} services" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(j))
-      val result = get(routes.SelectServiceController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.SelectServiceController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe OK
     })
   }
@@ -89,11 +89,11 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
         allOptions.foreach(o => s"redirect to the next page after storing answer of ${o} for ${j.getClientType}" in {
           authoriseAsAgent()
           await(journeyService.saveJourney(j))
-          val result = post(routes.SelectServiceController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+          val result = post(routes.SelectServiceController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
             "clientService" -> Seq(o)
           ))
           result.status shouldBe SEE_OTHER
-          result.header("Location").value shouldBe routes.EnterClientIdController.show(JourneyType.AuthorisationRequest).url
+          result.header("Location").value shouldBe routes.EnterClientIdController.show(AgentJourneyType.AuthorisationRequest).url
         }))
     })
     allClientTypeAuthJourneys.foreach(j => {
@@ -101,18 +101,18 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
         allOptions.foreach(o => s"redirect to the next page after storing answer of ${o} for ${j.getClientType}" in {
           authoriseAsAgent()
           await(journeyService.saveJourney(j))
-          val result = post(routes.SelectServiceController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+          val result = post(routes.SelectServiceController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
             "clientService" -> Seq(o)
           ))
           result.status shouldBe SEE_OTHER
-          result.header("Location").value shouldBe routes.ServiceRefinementController.show(JourneyType.AuthorisationRequest).url
+          result.header("Location").value shouldBe routes.ServiceRefinementController.show(AgentJourneyType.AuthorisationRequest).url
         }))
     })
   
     "show an error when no selection is made" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(personalAuthorisationRequestJourney))
-      val result = post(routes.SelectServiceController.onSubmit(JourneyType.AuthorisationRequest).url)("")
+      val result = post(routes.SelectServiceController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }
@@ -120,21 +120,21 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
   "GET /agent-cancel-authorisation/select-service" should {
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
-      val result = get(routes.SelectServiceController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.SelectServiceController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
     }
     "redirect to the journey start when no client type present" in {
       authoriseAsAgent()
-      await(journeyService.saveJourney(AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = None)))
-      val result = get(routes.SelectServiceController.show(JourneyType.AgentCancelAuthorisation).url)
+      await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AgentCancelAuthorisation, clientType = None)))
+      val result = get(routes.SelectServiceController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
     allClientTypeDeAuthJourneys.foreach(j => s"display the select service page for ${j.getClientType} services" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(j))
-      val result = get(routes.SelectServiceController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.SelectServiceController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe OK
     })
   }
@@ -145,11 +145,11 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
         allOptions.foreach(o => s"redirect to the next page after storing answer of ${o} for ${j.getClientType}" in {
           authoriseAsAgent()
           await(journeyService.saveJourney(j))
-          val result = post(routes.SelectServiceController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+          val result = post(routes.SelectServiceController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
             "clientService" -> Seq(o)
           ))
           result.status shouldBe SEE_OTHER
-          result.header("Location").value shouldBe routes.EnterClientIdController.show(JourneyType.AgentCancelAuthorisation).url
+          result.header("Location").value shouldBe routes.EnterClientIdController.show(AgentJourneyType.AgentCancelAuthorisation).url
         })))
 
     allClientTypeDeAuthJourneys.foreach(j =>
@@ -157,17 +157,17 @@ class SelectServiceControllerISpec extends ComponentSpecHelper with AuthStubs {
         allOptions.foreach(o => s"redirect to the refinement page after storing answer of ${o} for ${j.getClientType}" in {
           authoriseAsAgent()
           await(journeyService.saveJourney(j))
-          val result = post(routes.SelectServiceController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+          val result = post(routes.SelectServiceController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
             "clientService" -> Seq(o)
           ))
           result.status shouldBe SEE_OTHER
-          result.header("Location").value shouldBe routes.ServiceRefinementController.show(JourneyType.AgentCancelAuthorisation).url
+          result.header("Location").value shouldBe routes.ServiceRefinementController.show(AgentJourneyType.AgentCancelAuthorisation).url
         })))
     
     "show an error when no selection is made" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(personalAgentCancelAuthorisationJourney))
-      val result = post(routes.SelectServiceController.onSubmit(JourneyType.AgentCancelAuthorisation).url)("")
+      val result = post(routes.SelectServiceController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/ServiceRefinementControllerISpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
@@ -32,87 +32,87 @@ class ServiceRefinementControllerISpec extends ComponentSpecHelper with AuthStub
   }
 
   "GET /authorisation-request/refine-service" should {
-    val journey = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
-      val result = get(routes.ServiceRefinementController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.ServiceRefinementController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
     }
     "redirect to the journey start when no service present" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey.copy(clientService = None)))
-      val result = get(routes.ServiceRefinementController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.ServiceRefinementController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AuthorisationRequest).url
     }
     "display the refine service page" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
-      val result = get(routes.ServiceRefinementController.show(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.ServiceRefinementController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe OK
     }
   }
 
   "POST /authorisation-request/refine-service" should {
-    val journey = AgentJourney(journeyType = JourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to the next page after storing answer" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
-      val result = post(routes.ServiceRefinementController.onSubmit(JourneyType.AuthorisationRequest).url)(Map(
+      val result = post(routes.ServiceRefinementController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
         "clientService" -> Seq("HMRC-TERSNT-ORG")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.EnterClientIdController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.EnterClientIdController.show(AgentJourneyType.AuthorisationRequest).url
     }
 
     "show an error when no selection is made" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
-      val result = post(routes.ServiceRefinementController.onSubmit(JourneyType.AuthorisationRequest).url)("")
+      val result = post(routes.ServiceRefinementController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }
 
   "GET /agent-cancel-authorisation/refine-service" should {
-    val journey = AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = AgentJourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to ASA dashboard when no journey session present" in {
       authoriseAsAgent()
-      val result = get(routes.ServiceRefinementController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.ServiceRefinementController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
     }
     "redirect to the journey start when no service present" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey.copy(clientService = None)))
-      val result = get(routes.ServiceRefinementController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.ServiceRefinementController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
     "display the refine service page" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
-      val result = get(routes.ServiceRefinementController.show(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.ServiceRefinementController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe OK
     }
   }
 
   "POST /agent-cancel-authorisation/refine-service" should {
-    val journey = AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
+    val journey = AgentJourney(journeyType = AgentJourneyType.AgentCancelAuthorisation, clientType = Some("trust"), clientService = Some("HMRC-TERS-ORG"))
     "redirect to the enter client id page after storing answer" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
-      val result = post(routes.ServiceRefinementController.onSubmit(JourneyType.AgentCancelAuthorisation).url)(Map(
+      val result = post(routes.ServiceRefinementController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
         "clientService" -> Seq("HMRC-TERS-ORG")
       ))
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.EnterClientIdController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.EnterClientIdController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
 
     "show an error when no selection is made" in {
       authoriseAsAgent()
       await(journeyService.saveJourney(journey))
-      val result = post(routes.ServiceRefinementController.onSubmit(JourneyType.AgentCancelAuthorisation).url)("")
+      val result = post(routes.ServiceRefinementController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)("")
       result.status shouldBe BAD_REQUEST
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartAgentJourneyControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/StartAgentJourneyControllerISpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
 class StartAgentJourneyControllerISpec extends ComponentSpecHelper with AuthStubs {
@@ -25,18 +25,18 @@ class StartAgentJourneyControllerISpec extends ComponentSpecHelper with AuthStub
   "GET /authorisation-request/" should {
     "redirect to the select client type page" in {
       authoriseAsAgent()
-      val result = get(routes.StartJourneyController.startJourney(JourneyType.AuthorisationRequest).url)
+      val result = get(routes.StartJourneyController.startJourney(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AuthorisationRequest).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AuthorisationRequest).url
     }
   }
 
   "GET /agent-cancel-authorisation/" should {
     "redirect to the select client type page" in {
       authoriseAsAgent()
-      val result = get(routes.StartJourneyController.startJourney(JourneyType.AgentCancelAuthorisation).url)
+      val result = get(routes.StartJourneyController.startJourney(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.SelectClientTypeController.show(JourneyType.AgentCancelAuthorisation).url
+      result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AgentCancelAuthorisation).url
     }
   }
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AgentClientRelationshipStub.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AgentClientRelationshipStub.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.utils
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.Status.NO_CONTENT
 import play.api.test.Helpers.{NOT_FOUND, OK}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.{stubGet, stubPost}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.{stubGet, stubPost, stubPut}
 
 trait AgentClientRelationshipStub {
 
@@ -29,11 +29,11 @@ trait AgentClientRelationshipStub {
   def givenNotFoundForServiceAndClient(service: String, clientId: String): StubMapping = stubGet(
     s"/agent-client-relationships/client/$service/details/$clientId", NOT_FOUND, "")
 
-  def givenAcceptAuthorisation(invitationId: String, status: Int): StubMapping = stubPost(
+  def givenAcceptAuthorisation(invitationId: String, status: Int): StubMapping = stubPut(
     s"/agent-client-relationships/authorisation-response/accept/$invitationId", status, "")
 
-  def givenRejectAuthorisation(invitationId: String, status: Int): StubMapping = stubPost(
-    s"/agent-client-relationships/authorisation-response/reject/$invitationId", status, "")
+  def givenRejectAuthorisation(invitationId: String, status: Int): StubMapping = stubPut(
+    s"/agent-client-relationships/client/authorisation-response/reject/$invitationId", status, "")
 
   def givenCancelAuthorisation(arn: String): StubMapping = stubPost(
     s"/agent-client-relationships/agent/$arn/remove-authorisation", NO_CONTENT, "")

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/AgentClientRelationshipsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/AgentClientRelationshipsServiceSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentClientRelationshipsService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -56,7 +56,7 @@ class AgentClientRelationshipsServiceSpec extends AnyWordSpecLike with Matchers 
     None
   )
   val testJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     Some("testType"),
     Some("testService")
   )

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetAgentJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetAgentJourneyActionSpec.scala
@@ -29,7 +29,7 @@ import play.api.mvc.*
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, redirectLocation, status}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentJourneyService, ClientJourneyService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,7 +43,7 @@ class GetAgentJourneyActionSpec extends AnyWordSpecLike with Matchers with Optio
   }
   class FakeController(getJourneyAction: GetJourneyAction,
                        actionBuilder: DefaultActionBuilder) {
-    def route(journeyTypeFromUrl: JourneyType): Action[AnyContent] =
+    def route(journeyTypeFromUrl: AgentJourneyType): Action[AnyContent] =
       (actionBuilder andThen fakeAuthAction andThen getJourneyAction.agentJourneyAction(journeyTypeFromUrl)) {
         journeyRequest =>
           Results.Ok(Json.toJson(journeyRequest.journey).toString)
@@ -74,24 +74,24 @@ class GetAgentJourneyActionSpec extends AnyWordSpecLike with Matchers with Optio
   "agentJourneyAction" should {
     "successfully retrieve journey and continue if it matches the url journey type" in {
       val testJourney = AgentJourney(
-        JourneyType.AuthorisationRequest
+        AgentJourneyType.AuthorisationRequest
       )
       when(mockAgentJourneyService.getJourney(any(), any()))
         .thenReturn(Future.successful(Some(testJourney)))
 
-      val result = testController.route(JourneyType.AuthorisationRequest)(fakeRequest)
+      val result = testController.route(AgentJourneyType.AuthorisationRequest)(fakeRequest)
 
       status(result) shouldBe OK
       contentAsJson(result).as[AgentJourney] shouldBe testJourney
     }
     "successfully retrieve journey and redirect to ASA if it does not match the url journey type" in {
       val testJourney = AgentJourney(
-        JourneyType.AuthorisationRequest
+        AgentJourneyType.AuthorisationRequest
       )
       when(mockAgentJourneyService.getJourney(any(), any()))
         .thenReturn(Future.successful(Some(testJourney)))
 
-      val result = testController.route(JourneyType.AgentCancelAuthorisation)(fakeRequest)
+      val result = testController.route(AgentJourneyType.AgentCancelAuthorisation)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value shouldBe "http://localhost:9401/agent-services-account/home"
@@ -100,7 +100,7 @@ class GetAgentJourneyActionSpec extends AnyWordSpecLike with Matchers with Optio
       when(mockAgentJourneyService.getJourney(any(), any()))
         .thenReturn(Future.successful(None))
 
-      val result = testController.route(JourneyType.AuthorisationRequest)(fakeRequest)
+      val result = testController.route(AgentJourneyType.AuthorisationRequest)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value shouldBe "http://localhost:9401/agent-services-account/home"

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/GetClientJourneyActionSpec.scala
@@ -29,8 +29,7 @@ import play.api.mvc.*
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AgentJourneyService, ClientJourneyService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -77,7 +76,7 @@ class GetClientJourneyActionSpec extends AnyWordSpecLike with Matchers with Opti
   "clientJourneyAction" should {
     "successfully retrieve journey and continue" in {
       val testJourney = ClientJourney(
-        JourneyType.ClientResponse
+        "authorisation-response"
       )
       when(mockClientJourneyService.getJourney(any(), any()))
         .thenReturn(Future.successful(Some(testJourney)))
@@ -95,7 +94,7 @@ class GetClientJourneyActionSpec extends AnyWordSpecLike with Matchers with Opti
       val result = testController.route()(fakeRequest)
 
       status(result) shouldBe OK
-      contentAsJson(result).as[ClientJourney] shouldBe ClientJourney(journeyType = ClientResponse)
+      contentAsJson(result).as[ClientJourney] shouldBe ClientJourney(journeyType = "authorisation-response")
 
     }
   }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyTypeSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/AgentJourneyTypeSpec.scala
@@ -23,14 +23,14 @@ import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
 class AgentJourneyTypeSpec extends AnyWordSpecLike with Matchers {
 
   "JourneyType format" should {
-    JourneyType.values.foreach(value => s"write $value to a json string and read it back" in {
+    AgentJourneyType.values.foreach(value => s"write $value to a json string and read it back" in {
       val jsString = JsString(value.toString)
-      Json.toJson[JourneyType](value) shouldBe jsString
-      Json.fromJson[JourneyType](jsString) shouldBe JsSuccess(value)
+      Json.toJson[AgentJourneyType](value) shouldBe jsString
+      Json.fromJson[AgentJourneyType](jsString) shouldBe JsSuccess(value)
     })
 
     "fail to read an unknown value" in {
-      Json.fromJson[JourneyType](JsString("invalid")) shouldBe JsError("Invalid JourneyType")
+      Json.fromJson[AgentJourneyType](JsString("invalid")) shouldBe JsError("Invalid JourneyType")
     }
   }
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPageSpec.scala
@@ -126,7 +126,7 @@ class CheckYourAnswerPageSpec extends ViewSpecSupport {
               rows = List((
                 questionSummaryList(taxService),
                 choice,
-                s"/agent-client-relationships/authorisation-response/confirm-consent/$invitationId"
+                s"/agent-client-relationships/authorisation-response/confirm-consent"
               ))
             ))
           }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPageSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.Pending
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.CheckYourAnswerPage
 
@@ -36,7 +36,7 @@ class CheckYourAnswerPageSpec extends ViewSpecSupport {
   val lastModifiedDate: String = "2024-12-01T12:00:00Z"
 
   val journey: ClientJourney = ClientJourney(
-    journeyType = JourneyType.ClientResponse
+    journeyType = "authorisation-response"
   )
 
   def journeyForService(serviceKey: String, choice: Boolean): ClientJourney = journey.copy(

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
@@ -21,7 +21,6 @@ import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ClientExitPage
@@ -38,7 +37,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
   case class ExpectedStrings(title: String, paragraphs: List[String])
 
   private def clientJourney(status:Option[InvitationStatus]): ClientJourney = ClientJourney(
-    journeyType = ClientResponse, agentName = Some(testAgentName), status = status, lastModifiedDate = Some(testLastModifiedDate)
+    journeyType = "authorisation-response", agentName = Some(testAgentName), status = status, lastModifiedDate = Some(testLastModifiedDate)
   )
 
   object Expected {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmConsentPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmConsentPageSpec.scala
@@ -21,7 +21,6 @@ import org.jsoup.nodes.Document
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientType.personal
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ExistingMainAgent
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.client.ConfirmConsentForm
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.ClientResponse
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ConfirmConsentPage
@@ -44,7 +43,7 @@ class ConfirmConsentPageSpec extends ViewSpecSupport:
   val suppRoleServices: Seq[String] = Seq("HMRC-MTD-IT-SUPP")
 
   val baseJourneyModel: ClientJourney = ClientJourney(
-    ClientResponse,
+    "authorisation-response",
     invitationId = Some("ABC123"),
     agentName = Some(newAgentName),
     clientType = Some(personal)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPageSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.client
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AuthorisationRequestInfoForClient
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{Accepted, PartialAuth, Rejected}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ConfirmationPage
+
+import scala.language.postfixOps
+
+class ConfirmationPageSpec extends ViewSpecSupport {
+
+  val viewTemplate: ConfirmationPage = app.injector.instanceOf[ConfirmationPage]
+  val testInvitationId: String = "AB1234567890"
+  val testClientName: String = "Test Client"
+  val agentName: String = "ABC Accountants"
+  val serviceLabels: Map[String, String] = Map(
+    "HMRC-MTD-IT" -> "Making Tax Digital for Income Tax",
+    "PERSONAL-INCOME-RECORD" -> "Income Record Viewer",
+    "HMRC-MTD-VAT" -> "VAT",
+    "HMRC-CGT-PD" -> "Capital Gains Tax on UK property account",
+    "HMRC-PPT-ORG" -> "Plastic Packaging Tax",
+    "HMRC-CBC-ORG" -> "Country-by-country reporting",
+    "HMRC-PILLAR2-ORG" -> "Pillar 2 Top-up Taxes",
+    "HMRC-TERS-ORG" -> "Trusts and Estates",
+    "HMRC-TERSNT-ORG" -> "Trusts and Estates"
+  )
+  val rejectedServiceLabels: Map[String, String] = Map(
+    "HMRC-MTD-IT" -> "manage your Making Tax Digital for Income Tax",
+    "PERSONAL-INCOME-RECORD" -> "view your personal income record",
+    "HMRC-MTD-VAT" -> "manage your VAT",
+    "HMRC-CGT-PD" -> "manage your Capital Gains Tax on UK property account",
+    "HMRC-PPT-ORG" -> "manage your Plastic Packaging Tax",
+    "HMRC-CBC-ORG" -> "manage your Country-by-country reporting",
+    "HMRC-PILLAR2-ORG" -> "manage your Pillar 2 Top-up Taxes",
+    "HMRC-TERS-ORG" -> "manage a trust or an estate",
+    "HMRC-TERSNT-ORG" -> "manage a trust or an estate"
+  )
+
+  val confirmationData: AuthorisationRequestInfoForClient = AuthorisationRequestInfoForClient(
+    agentName = agentName,
+    service = "HMRC-MTD-IT",
+    status = Rejected
+  )
+
+  private val completeJourney: ClientJourney = ClientJourney(
+    "authorisation-response",
+    journeyComplete = Some("invitationId")
+  )
+
+  private def agentRoleForService(service: String) = service match {
+    case "HMRC-MTD-IT" => s"main agent for ${serviceLabels(service)}"
+    case "HMRC-MTD-IT-SUPP" => s"supporting agent for ${serviceLabels(service)}"
+    case _ => s"agent for ${serviceLabels(service)}"
+  }
+
+  "ConfirmationPage view for accepting an invitation" should {
+    List(Accepted, PartialAuth, Rejected).foreach(decision =>
+      for (taxService <- serviceLabels.keySet.toList) {
+        implicit val journeyRequest: ClientJourneyRequest[?] = new ClientJourneyRequest(completeJourney, request)
+        val view: HtmlFormat.Appendable = viewTemplate(confirmationData.copy(service = taxService, status = decision))
+        val doc: Document = Jsoup.parse(view.body)
+        s"include the correct h1 text for ${decision.toString} $taxService" in {
+          val expectedHeading = decision match {
+            case Accepted => s"You have authorised $agentName"
+            case PartialAuth => s"You have authorised $agentName"
+            case _ => s"You declined a request from $agentName"
+          }
+          doc.mainContent.extractText("h1.govuk-panel__title", 1).value shouldBe expectedHeading
+        }
+        s"include the correct p1 text for ${decision.toString} $taxService" in {
+          val expectedContent = decision match {
+            case Accepted => s"$agentName is now your ${agentRoleForService(taxService)}."
+            case PartialAuth => s"$agentName is now your ${agentRoleForService(taxService)}."
+            case _ => s"You have not given permission for $agentName to ${rejectedServiceLabels(taxService)}."
+          }
+          doc.mainContent.extractText(p, 1).value shouldBe expectedContent
+        }
+      }
+    )
+  }
+
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPageSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.Pending
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ConsentInformationPage
 
@@ -79,7 +79,7 @@ class ConsentInformationPageSpec extends ViewSpecSupport {
   )
 
   val journey: ClientJourney = ClientJourney(
-    journeyType = JourneyType.ClientResponse
+    journeyType = "authorisation-response"
   )
 
   def journeyForService(serviceKey: String): ClientJourney = journey.copy(

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentCancelAuthorisationCompletePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentCancelAuthorisationCompletePageSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AgentCancelAuthorisationResponse
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.AgentCancelAuthorisationCompletePage
 
@@ -51,7 +51,7 @@ class AgentCancelAuthorisationCompletePageSpec extends ViewSpecSupport {
   )
 
   private val completeJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     journeyComplete = Some("2024-12-25"),
     confirmationClientName = Some(testClientName),
     confirmationService = Some("HMRC-MTD-IT")

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentJourneyExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentJourneyExitPageSpec.scala
@@ -27,8 +27,8 @@ class AgentJourneyExitPageSpec extends ViewSpecSupport {
 
   val viewTemplate: JourneyExitPage = app.injector.instanceOf[JourneyExitPage]
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   case class ExpectedStrings(authorisationTitle: String, cancelAuthorisationTitle: String)
   private val supportedErrorCodes: Map[JourneyExitType, ExpectedStrings] = Map(
@@ -46,7 +46,7 @@ class AgentJourneyExitPageSpec extends ViewSpecSupport {
     supportedErrorCodes.map(errorCode => s"JourneyErrorPage for ${errorCode._1} ${j.journeyType.toString} view" should {
       implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", j, request)
       val expectedStrings = errorCode._2
-      val title = if (j.journeyType == JourneyType.AuthorisationRequest) expectedStrings.authorisationTitle else expectedStrings.cancelAuthorisationTitle
+      val title = if (j.journeyType == AgentJourneyType.AuthorisationRequest) expectedStrings.authorisationTitle else expectedStrings.cancelAuthorisationTitle
       val view: HtmlFormat.Appendable = viewTemplate(j.journeyType, errorCode._1)
       val doc: Document = Jsoup.parse(view.body)
       "have the right title" in {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CheckYourAnswersPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CheckYourAnswersPageSpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.CheckYour
 class CheckYourAnswersPageSpec extends ViewSpecSupport {
 
   val viewTemplate: CheckYourAnswersPage = app.injector.instanceOf[CheckYourAnswersPage]
-  private val journeyType = JourneyType.AuthorisationRequest
+  private val journeyType = AgentJourneyType.AuthorisationRequest
   private val exampleClientId: String = "1234567890"
   private val exampleKnownFact: String = "AA11AA"
   private val clientName = "Test Name"

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmCancellationPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmCancellationPageSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.ConfirmCa
 class ConfirmCancellationPageSpec extends ViewSpecSupport {
 
   val viewTemplate: ConfirmCancellationPage = app.injector.instanceOf[ConfirmCancellationPage]
-  private val journeyType = JourneyType.AgentCancelAuthorisation
+  private val journeyType = AgentJourneyType.AgentCancelAuthorisation
   val exampleClientId: String = "1234567890"
   val exampleKnownFact: String = "AA11AA"
   val clientName = "Test Name"

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPageSpec.scala
@@ -32,11 +32,11 @@ class ConfirmClientPageSpec extends ViewSpecSupport {
   val viewTemplate: ConfirmClientPage = app.injector.instanceOf[ConfirmClientPage]
 
   private val authorisationRequestJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     clientDetailsResponse = Some(ClientDetailsResponse("TestName", None, None, Nil, None, false, None))
   )
   private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(
-    JourneyType.AgentCancelAuthorisation,
+    AgentJourneyType.AgentCancelAuthorisation,
     clientDetailsResponse = Some(ClientDetailsResponse("TestName", None, None, Nil, None, false, None))
   )
 
@@ -58,7 +58,7 @@ class ConfirmClientPageSpec extends ViewSpecSupport {
     s"Confirm client view for ${j.journeyType}" should {
       implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", j, request)
 
-      val title = if(j.journeyType == JourneyType.AuthorisationRequest) Expected.authorisationTitle else
+      val title = if(j.journeyType == AgentJourneyType.AuthorisationRequest) Expected.authorisationTitle else
         Expected.deAuthorisationTitle
       val form: Form[Boolean] = ConfirmClientForm.form(ClientConfirmationFieldName, clientName, j.journeyType.toString)
       val view: HtmlFormat.Appendable = viewTemplate(form)
@@ -74,7 +74,7 @@ class ConfirmClientPageSpec extends ViewSpecSupport {
 
       "render input Radio form for confirm client page" in {
         doc.mainContent.extractRadios() shouldBe Some(TestRadioGroup(
-          legend = if(j.journeyType == JourneyType.AuthorisationRequest) Expected.authorisationLabel else
+          legend = if(j.journeyType == AgentJourneyType.AuthorisationRequest) Expected.authorisationLabel else
             Expected.deAuthorisationLabel,
           options = List((Expected.radioTrue, "true"), (Expected.radioFalse, "false")),
           hint = None
@@ -86,7 +86,7 @@ class ConfirmClientPageSpec extends ViewSpecSupport {
       }
 
       "render error for the correct journey" in {
-        val expectedError = if(j.journeyType == JourneyType.AuthorisationRequest) Expected.authorisationErrorRequired else
+        val expectedError = if(j.journeyType == AgentJourneyType.AuthorisationRequest) Expected.authorisationErrorRequired else
           Expected.deAuthorisationErrorRequired
         val formWithErrors = form.bind(Map.empty)
         val viewWithErrors: HtmlFormat.Appendable = viewTemplate(formWithErrors)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePageSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AuthorisationRequestInfo
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, JourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney, AgentJourneyType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.CreateAuthorisationRequestCompletePage
 
@@ -55,7 +55,7 @@ class CreateAuthorisationRequestCompletePageSpec extends ViewSpecSupport {
   )
 
   private val completeJourney: AgentJourney = AgentJourney(
-    JourneyType.AuthorisationRequest,
+    AgentJourneyType.AuthorisationRequest,
     journeyComplete = Some(testInvitationId)
   )
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPageSpec.scala
@@ -29,8 +29,8 @@ class EnterClientFactPageSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   case class ExpectedStrings(authorisationTitle: String, cancelAuthorisationTitle: String)
 
@@ -80,7 +80,7 @@ class EnterClientFactPageSpec extends ViewSpecSupport {
           ),
           request
         )
-        val title = if j.journeyType == JourneyType.AuthorisationRequest then expectedStrings.authorisationTitle else expectedStrings.cancelAuthorisationTitle
+        val title = if j.journeyType == AgentJourneyType.AuthorisationRequest then expectedStrings.authorisationTitle else expectedStrings.cancelAuthorisationTitle
         val form = EnterClientFactForm.form(
           knownFactType.fieldConfiguration,
           service,

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientIdPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientIdPageSpec.scala
@@ -30,8 +30,8 @@ class EnterClientIdPageSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientIdPage = app.injector.instanceOf[EnterClientIdPage]
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   val ninoField: ClientDetailsConfiguration = ClientDetailsConfiguration(
     name = "nino",
@@ -206,7 +206,7 @@ class EnterClientIdPageSpec extends ViewSpecSupport {
       implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", j, request)
 
       val serviceStrings: ServiceStrings = mapOfFieldConfiguration(field)._2
-      val title = if (j.journeyType == JourneyType.AuthorisationRequest) serviceStrings.authorisationRequestTitle else serviceStrings.cancelAuthorisationTitle
+      val title = if (j.journeyType == AgentJourneyType.AuthorisationRequest) serviceStrings.authorisationRequestTitle else serviceStrings.cancelAuthorisationTitle
 
       val form: Form[String] = EnterClientIdForm.form(mapOfFieldConfiguration(field)._1, j.journeyType.toString)
       val view: HtmlFormat.Appendable = viewTemplate(form, mapOfFieldConfiguration(field)._1)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePageSpec.scala
@@ -34,7 +34,7 @@ class SelectAgentRolePageSpec extends ViewSpecSupport {
   val testPostcode = "AA1 1AA"
   val mainRole = "HMRC-MTD-IT"
   val supportingRole = "HMRC-MTD-IT-SUPP"
-  val journeyType: JourneyType = JourneyType.AuthorisationRequest
+  val journeyType: AgentJourneyType = AgentJourneyType.AuthorisationRequest
 
   object Expected {
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePageSpec.scala
@@ -22,7 +22,7 @@ import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.{AgentCancelAuthorisation, AuthorisationRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.{AgentCancelAuthorisation, AuthorisationRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.SelectClientServicePage
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientTypePageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientTypePageSpec.scala
@@ -40,7 +40,7 @@ class SelectClientTypePageSpec extends ViewSpecSupport {
   }
 
   "SelectClientType for authorisation request view" should {
-    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", AgentJourney(journeyType = JourneyType.AuthorisationRequest), request)
+    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest), request)
     val options: Seq[String] = Seq("personal", "business", "trust")
     val form: Form[String] = SelectFromOptionsForm.form("clientType", options, "authorisation-request")
     val view: HtmlFormat.Appendable = viewTemplate(form, options)
@@ -67,7 +67,7 @@ class SelectClientTypePageSpec extends ViewSpecSupport {
   }
 
   "SelectClientType for cancel authorisation view" should {
-    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", AgentJourney(journeyType = JourneyType.AgentCancelAuthorisation), request)
+    implicit val journeyRequest: AgentJourneyRequest[?] = new AgentJourneyRequest("", AgentJourney(journeyType = AgentJourneyType.AgentCancelAuthorisation), request)
     val options: Seq[String] = Seq("personal", "business", "trust")
     val form: Form[String] = SelectFromOptionsForm.form("clientType", options, "agent-cancel-authorisation")
     val view: HtmlFormat.Appendable = viewTemplate(form, options)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPageSpec.scala
@@ -22,7 +22,7 @@ import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.SelectFromOptionsForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.{AgentCancelAuthorisation, AuthorisationRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.{AgentCancelAuthorisation, AuthorisationRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.ServiceRefinementPage
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/CountrySpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/CountrySpec.scala
@@ -29,8 +29,8 @@ class CountrySpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
       s"EnterClientFactPage for country code ${j.journeyType.toString} view" should {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/DateSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/DateSpec.scala
@@ -22,7 +22,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientFactForm
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourney}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyType.AuthorisationRequest
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.AuthorisationRequest
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
 import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.clientFactPartials.Date
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/EmailSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/EmailSpec.scala
@@ -29,8 +29,8 @@ class EmailSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
     List("HMRC-CBC-ORG","HMRC-CBC-NONUK-ORG").foreach(enrolment =>

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/PostcodeSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/clientFactPartials/PostcodeSpec.scala
@@ -29,8 +29,8 @@ class PostcodeSpec extends ViewSpecSupport {
 
   val viewTemplate: EnterClientFactPage = app.injector.instanceOf[EnterClientFactPage]
 
-  private val authorisationRequestJourney: AgentJourney = AgentJourney(JourneyType.AuthorisationRequest)
-  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(JourneyType.AgentCancelAuthorisation)
+  private val authorisationRequestJourney: AgentJourney = AgentJourney(AgentJourneyType.AuthorisationRequest)
+  private val agentCancelAuthorisationJourney: AgentJourney = AgentJourney(AgentJourneyType.AgentCancelAuthorisation)
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
       s"EnterClientFactPage for postcode ${j.journeyType.toString} view" should {


### PR DESCRIPTION
Large because it touches a lot of files - the required route `authorisation-response/confirmation` was clashing with `:journeyType/confirmation` because the ClientResponse type was put into the JourneyType enum previously - I have now removed it as it is not a valid value for `:journeyType` only agent journeys can use those routes - I also renamed `JourneyType` to `AgentJourneyType` - this updated a lot of files with name changes... I also had to accommodate the possibility (with EMA in particular) of more than one invitation being found (an Accepted HMRC-MTD-IT plus Pending HMRC-MTD-IT-SUPP) so reworked that to accept a list of invitations and put forward the PENDING one and if none then fallback to the most recent one where the status can be reported on by the exit pages.