### PR TITLE
APB-9011 Add page/controller for decline request

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/Constants.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/Constants.scala
@@ -43,5 +43,6 @@ object Constants extends ServiceConstants {
   val AgentRoleFieldName = "agentRole"
   val ConfirmCancellationFieldName = "confirmCancellation"
   val ConfirmConsentFieldName = "confirmConsent"
+  val DeclineRequestFieldName = "confirmDecline"
 
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationController.scala
@@ -43,9 +43,8 @@ class ConsentInformationController @Inject()(agentClientRelationshipsConnector: 
 
   def show(uid: String, taxService: String): Action[AnyContent] = actions.getClientJourney(taxService).async:
     implicit journeyRequest =>
-      given Request[?] = journeyRequest.request
 
-      if serviceConfigurationService.validateUrlPart(taxService) then agentClientRelationshipsConnector
+      agentClientRelationshipsConnector
         .validateInvitation(uid, serviceConfigurationService.getServiceKeysForUrlPart(taxService))
         .flatMap {
           case Left("AGENT_SUSPENDED") => Future.successful(Redirect(routes.ClientExitController.showUnauthorised(AgentSuspended)))
@@ -67,4 +66,3 @@ class ConsentInformationController @Inject()(agentClientRelationshipsConnector: 
               case _ => Redirect(routes.ClientExitController.showClient(AlreadyRespondedToAuthorisationRequest))
             })
         }
-      else Future.successful(NotFound(pageNotFound()))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import com.google.inject.Inject
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{Cancelled, Expired, Pending}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.client.DeclineRequestForm
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientJourneyService, ClientServiceConfigurationService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.DeclineRequestPage
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.PageNotFound
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeclineRequestController @Inject()(mcc: MessagesControllerComponents,
+                                         actions: Actions,
+                                         declineRequestView: DeclineRequestPage,
+                                         pageNotFound: PageNotFound,
+                                         clientServiceConfig: ClientServiceConfigurationService,
+                                         clientJourneyService: ClientJourneyService,
+                                         agentClientRelationshipsConnector: AgentClientRelationshipsConnector)
+                                        (implicit ec: ExecutionContext,
+                                         appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
+
+  private def determineAgentRole(service: String) = clientServiceConfig.supportsAgentRoles(service) match {
+    case true if clientServiceConfig.supportingAgentServices.contains(service) => "suppAgent"
+    case true => "mainAgent"
+    case false => "agent"
+  }
+
+  def show(uid: String, taxService: String): Action[AnyContent] = actions.getClientJourney(taxService).async:
+    implicit request =>
+      agentClientRelationshipsConnector
+        .validateInvitation(uid, clientServiceConfig.getServiceKeysForUrlPart(taxService))
+        .flatMap {
+          case Left("AGENT_SUSPENDED") =>
+            Future.successful(Redirect(routes.ClientExitController.showUnauthorised(AgentSuspended)))
+          case Left("INVITATION_OR_AGENT_RECORD_NOT_FOUND") =>
+            Future.successful(Redirect(routes.ClientExitController.showUnauthorised(NoOutstandingRequests)))
+          case Right(response) =>
+            val newJourney = request.journey.copy(
+              invitationId = Some(response.invitationId),
+              serviceKey = Some(response.serviceKey),
+              agentName = Some(response.agentName),
+              status = Some(response.status),
+              lastModifiedDate = Some(response.lastModifiedDate),
+              existingMainAgent = response.existingMainAgent,
+              clientType = response.clientType
+            )
+            val updatedRequest = ClientJourneyRequest(newJourney, request.request)
+            val agentRole = determineAgentRole(response.serviceKey)
+            val form = DeclineRequestForm.form(response.agentName)
+            clientJourneyService.saveJourney(newJourney).map(_ => response.status match {
+              case Pending =>
+                Ok(declineRequestView(form, agentRole, uid, taxService)(updatedRequest, request2Messages, appConfig))
+              case Expired =>
+                Redirect(routes.ClientExitController.showClient(AuthorisationRequestExpired))
+              case Cancelled =>
+                Redirect(routes.ClientExitController.showClient(AuthorisationRequestCancelled))
+              case _ =>
+                Redirect(routes.ClientExitController.showClient(AlreadyRespondedToAuthorisationRequest))
+            })
+        }
+
+  def submit(uid: String, taxService: String): Action[AnyContent] = actions.getClientJourney(taxService).async:
+    implicit request =>
+      (request.journey.serviceKey, request.journey.agentName, request.journey.invitationId) match {
+        case (Some(service), Some(agentName), Some(invId)) =>
+          val form = DeclineRequestForm.form(agentName)
+          form.bindFromRequest().fold(
+            formWithErrors => {
+              val agentRole = determineAgentRole(service)
+              Future.successful(BadRequest(declineRequestView(formWithErrors, agentRole, uid, taxService)))
+            },
+            {
+              case true =>
+                for {
+                  _ <- agentClientRelationshipsConnector.rejectAuthorisation(invId)
+                  _ <- clientJourneyService.saveJourney(ClientJourney(
+                    journeyType = request.journey.journeyType,
+                    journeyComplete = Some(invId)
+                  ))
+                } yield Redirect(routes.ConfirmationController.show)
+              case false => Future.successful(Redirect(routes.ConsentInformationController.show(uid, taxService)))
+            }
+          )
+        case _ => Future.successful(BadRequest)
+      }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartController.scala
@@ -23,10 +23,9 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientServiceConfigurationService
-import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.{AuthoriseAgentStartPage, PageNotFound}
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.AuthoriseAgentStartPage
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.PageNotFound
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/client/DeclineRequestForm.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/client/DeclineRequestForm.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.client
+
+import play.api.data.Form
+import play.api.data.Forms.{boolean, optional, single}
+import play.api.i18n.Messages
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.DeclineRequestFieldName
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers.FormFieldHelper
+
+object DeclineRequestForm extends FormFieldHelper {
+  def form(agentName: String)(implicit messages: Messages): Form[Boolean] = Form(
+    single(
+      DeclineRequestFieldName -> optional(boolean)
+        .verifying(mandatoryBoolean(DeclineRequestFieldName, agentName))
+        .transform(_.getOrElse(false), Some(_))
+    )
+  )
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/AuthoriseAgentStartPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/AuthoriseAgentStartPage.scala.html
@@ -47,7 +47,7 @@
     ))
 
     <p class="govuk-body">
-        <a href=@{s"/agent-client-relationships/authorisation-response/$uid/$taxService/decline-request"} class="govuk-link">@messages(s"$key.link.text2", agentName)</a>
+        <a href="@routes.DeclineRequestController.show(uid, taxService).url" class="govuk-link">@messages(s"$key.link.text2", agentName)</a>
     </p>
 }
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/DeclineRequestPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/DeclineRequestPage.scala.html
@@ -1,0 +1,76 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.DeclineRequestFieldName
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourneyRequest
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.Layout
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+
+@this(layout: Layout, govukButton: GovukButton, govukRadios: GovukRadios, formWithCSRF: FormWithCSRF)
+
+@(form: Form[Boolean], agentRoleKey: String, uid: String, taxService: String)(implicit request: ClientJourneyRequest[_], messages: Messages, appConfig: AppConfig)
+
+@key = @{"confirmDecline"}
+@serviceKey = @{request.journey.getServiceKey}
+@agentName = @{request.journey.getAgentName}
+@agentRole = @{messages(s"$key.$agentRoleKey")}
+@taxServiceName = @{messages(serviceKey)}
+@pageTitle = @{messages(s"$key.title")}
+@serviceName = @{messages("service.name.clients")}
+
+@layout(pageTitle, Some(serviceName), Some(form)) {
+
+  <h2 class="govuk-caption-xl">@messages(serviceKey)</h2>
+  <h1 class="govuk-heading-xl">@pageTitle</h1>
+
+  <p class="govuk-body">@messages(s"$key.p1", agentName, agentRole, taxServiceName)</p>
+
+  @if(agentRoleKey == "mainAgent" || agentRoleKey == "suppAgent") {
+    <p class="govuk-body" id="agent-role-guidance">
+      @messages(s"$key.p2")
+      <a class="govuk-link" target="_blank" href="@appConfig.guidanceUrlForAgentRoles">@messages(s"$key.p2.link")</a>.
+    </p>
+  }
+
+  <p class="govuk-body">@messages(s"$key.p3", agentName, agentRole, taxServiceName)</p>
+  <p class="govuk-body">@messages(s"$key.p4")</p>
+
+  @formWithCSRF(action = routes.DeclineRequestController.submit(uid, taxService)) {
+    @govukRadios(Radios(
+      fieldset = Some(Fieldset(
+        legend = Some(Legend(
+          content = Text(messages(s"$key.label", agentName)),
+          isPageHeading = false,
+          classes = "govuk-fieldset__legend--m"
+        ))
+      )),
+      items = Seq("true", "false").map(trueOrFalse =>
+        RadioItem(
+          id = Some(DeclineRequestFieldName),
+          content = Text(messages(s"$key.$trueOrFalse")),
+          value = Some(trueOrFalse)
+        )
+      )
+    ).withFormField(form(DeclineRequestFieldName)))
+
+    @govukButton(Button(
+      id = Some("continueButton"),
+      content = Text(messages("continue.button"))
+    ))
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,6 +23,9 @@ GET        /appoint-someone-to-deal-with-HMRC-for-you/:uid/:normalizedAgentName/
 
 GET        /authorisation-response/:uid/:taxService/consent-information                 uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConsentInformationController.show(uid: String, taxService: String)
 
+GET        /authorisation-response/:uid/:taxService/confirm-decline                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.DeclineRequestController.show(uid: String, taxService: String)
+POST       /authorisation-response/:uid/:taxService/confirm-decline                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.DeclineRequestController.submit(uid: String, taxService: String)
+
 GET        /authorisation-response/exit-auth/:exitType                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showClient(exitType: ClientExitType)
 
 GET        /authorisation-response/exit-public/:exitType                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showUnauthorised(exitType: ClientExitType)

--- a/conf/messages
+++ b/conf/messages
@@ -696,6 +696,23 @@ confirmConsent.HMRC-PILLAR2-ORG.list.item5=finalise your overall tax position
 confirmConsent.HMRC-PILLAR2-ORG.list.item6=view your calculations and amounts owed and paid
 
 # ________________________________________________________________________________
+# Client confirm decline of request
+# ________________________________________________________________________________
+confirmDecline.title=Decline a request
+confirmDecline.agent=agent
+confirmDecline.mainAgent=main agent
+confirmDecline.suppAgent=supporting agent
+confirmDecline.p1={0} want to be your {1} for {2}.
+confirmDecline.p2=Read the guidance about
+confirmDecline.p2.link=the difference between main agents and supporting agents (opens in a new tab)
+confirmDecline.p3=If you decline the request from {0}, they will not be able to act as your {1} for {2}.
+confirmDecline.p4=You can change your mind later - just ask them to send you another request.
+confirmDecline.label=Do you want to decline the request from {0}?
+confirmDecline.true=Yes
+confirmDecline.false=No, I want to consider this request
+confirmDecline.error.required=Select ''yes'' if you want to decline the request from {0}
+
+# ________________________________________________________________________________
 # Client journey check your answer page
 # ________________________________________________________________________________
 checkYourAnswer.title=Check your answer

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -536,3 +536,20 @@ confirmConsent.HMRC-PILLAR2-ORG.list.item3=bwrw golwg dros a newid eich manylion
 confirmConsent.HMRC-PILLAR2-ORG.list.item4=rhoi manylion banc i CThEF ar gyfer ad-daliadau pan fo ad-daliad yn ddyledus
 confirmConsent.HMRC-PILLAR2-ORG.list.item5=cwblhau’ch sefyllfa dreth gyffredinol
 confirmConsent.HMRC-PILLAR2-ORG.list.item6=bwrw golwg dros eich cyfrifiadau a’r symiau dyledus a’r symiau sydd wedi’u talu.
+
+# ________________________________________________________________________________
+# Client confirm decline of request
+# ________________________________________________________________________________
+confirmDecline.title=<translation needed>
+confirmDecline.agent=<translation needed>
+confirmDecline.mainAgent=<translation needed>
+confirmDecline.suppAgent=<translation needed>
+confirmDecline.p1=<translation needed>
+confirmDecline.p2=<translation needed>
+confirmDecline.p2.link=<translation needed>
+confirmDecline.p3=<translation needed>
+confirmDecline.p4=<translation needed>
+confirmDecline.label=<translation needed>
+confirmDecline.true=Iawn
+confirmDecline.false=<translation needed>
+confirmDecline.error.required=<translation needed>

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import play.api.http.Status.*
+import play.api.libs.json.{JsObject, Json}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.DeclineRequestFieldName
+import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.ClientJourney
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{ClientJourneyService, ClientServiceConfigurationService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubPost
+import uk.gov.hmrc.http.HeaderCarrier
+
+class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs with AgentClientRelationshipStub:
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  val testUid = "ABCD"
+
+  val taxServices: Map[String, String] = Map(
+    "income-tax" -> "HMRC-MTD-IT",
+    "income-record-viewer" -> "HMRC-PT",
+    "vat" -> "HMRC-MTD-VAT",
+    "capital-gains-tax-uk-property" -> "HMRC-CGT-PD",
+    "plastic-packaging-tax" -> "HMRC-PPT-ORG",
+    "country-by-country-reporting" -> "HMRC-CBC-ORG",
+    "pillar-2" -> "HMRC-PILLAR2-ORG",
+    "trusts-and-estates" -> "HMRC-TERS-ORG",
+  )
+
+  val validateInvitationUrl = s"/agent-client-relationships/client/validate-invitation"
+
+  def testValidateInvitationResponseJson(taxService: String, status: String = "Pending"): JsObject = Json.obj(
+    "invitationId" -> "AB1234567890",
+    "serviceKey" -> taxService,
+    "agentName" -> "Pep Guardi",
+    "status" -> status,
+    "lastModifiedDate" -> "2024-12-01T12:00:00Z",
+    "existingMainAgent" -> Json.obj(
+      "agencyName" -> "CFG Solutions",
+      "sameAgent" -> true
+    ),
+    "clientType" -> "personal"
+  )
+
+  val serviceConfigurationService: ClientServiceConfigurationService = app.injector.instanceOf[ClientServiceConfigurationService]
+  val agentClientRelationshipsConnector: AgentClientRelationshipsConnector = app.injector.instanceOf[AgentClientRelationshipsConnector]
+  val journeyService: ClientJourneyService = app.injector.instanceOf[ClientJourneyService]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    await(journeyService.deleteAllAnswersInSession(request))
+  }
+
+  "GET /authorisation-response/:uid/:taxService/confirm-decline" should:
+
+    "redirect to a InsufficientEnrolments exit page when the URL part is not valid for the user enrolments" in :
+      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+      val result = get(routes.DeclineRequestController.show(testUid, "vat").url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe "routes.ClientExitHandler.show(INSUFFICIENT_ENROLMENTS)" // TODO change to controller action when auth action is updated
+
+    "redirect to NoOutstandingRequests exit page when the invitation data is not found" in:
+      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+      stubPost(validateInvitationUrl, NOT_FOUND, "")
+      val result = get(routes.DeclineRequestController.show(testUid, "income-tax").url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(ClientExitType.NoOutstandingRequests).url
+
+    "redirect to AgentSuspended exit page when the agent is suspended" in:
+      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+      stubPost(validateInvitationUrl, FORBIDDEN, "")
+      val result = get(routes.DeclineRequestController.show(testUid, "income-tax").url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(ClientExitType.AgentSuspended).url
+
+    taxServices.keySet.foreach: taxService =>
+
+      s"display consent information page for $taxService" in:
+        authoriseAsClientWithEnrolments(taxServices(taxService))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService)).toString())
+        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        result.status shouldBe OK
+
+      s"redirect to expired exit page for $taxService" in:
+        authoriseAsClientWithEnrolments(taxServices(taxService))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Expired").toString())
+        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AuthorisationRequestExpired).url
+
+      s"redirect to cancelled exit page for $taxService" in:
+        authoriseAsClientWithEnrolments(taxServices(taxService))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Cancelled").toString())
+        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AuthorisationRequestCancelled).url
+
+      s"redirect to already responded exit page for $taxService" in:
+        authoriseAsClientWithEnrolments(taxServices(taxService))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Accepted").toString())
+        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AlreadyRespondedToAuthorisationRequest).url
+
+  "POST /authorisation-response/:uid/:taxService/confirm-decline" when:
+
+    val baseJourneyModel = ClientJourney(
+      journeyType = "authorisation-response",
+      serviceKey = Some("HMRC-MTD-IT"),
+      agentName = Some("Name"),
+      invitationId = Some("ABC123")
+    )
+
+    "the user selects 'Yes' to confirm their rejection" should:
+
+      "reject the invitation and redirect to the Confirmation page" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel))
+        givenRejectAuthorisation("ABC123", NO_CONTENT)
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+                         (Map(DeclineRequestFieldName -> Seq("true")))
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe routes.ConfirmationController.show.url
+
+      "return BadRequest when there is no service in session" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel.copy(serviceKey = None)))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+                         (Map(DeclineRequestFieldName -> Seq("true")))
+        result.status shouldBe BAD_REQUEST
+
+      "return BadRequest when there is no agent name in session" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel.copy(agentName = None)))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+                         (Map(DeclineRequestFieldName -> Seq("true")))
+        result.status shouldBe BAD_REQUEST
+
+      "return BadRequest when there is no invitation ID in session" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel.copy(invitationId = None)))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+                         (Map(DeclineRequestFieldName -> Seq("true")))
+        result.status shouldBe BAD_REQUEST
+
+    "the user selects 'No' to consider giving consent" should :
+
+      "redirect to the ConsentInformation page" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+                         (Map(DeclineRequestFieldName -> Seq("false")))
+        result.status shouldBe SEE_OTHER
+        result.header("Location").value shouldBe routes.ConsentInformationController.show(testUid, "income-tax").url
+
+      "return BadRequest when there is no service in session" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel.copy(serviceKey = None)))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+          (Map(DeclineRequestFieldName -> Seq("false")))
+        result.status shouldBe BAD_REQUEST
+
+      "return BadRequest when there is no agent name in session" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel.copy(agentName = None)))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+          (Map(DeclineRequestFieldName -> Seq("false")))
+        result.status shouldBe BAD_REQUEST
+
+      "return BadRequest when there is no invitation ID in session" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel.copy(invitationId = None)))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+          (Map(DeclineRequestFieldName -> Seq("false")))
+        result.status shouldBe BAD_REQUEST
+
+    "the user does not select an option" should :
+
+      "return BadRequest" in :
+        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
+        await(journeyService.saveJourney(baseJourneyModel))
+        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+                         (Map(DeclineRequestFieldName -> Seq("")))
+        result.status shouldBe BAD_REQUEST

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/DeclineRequestFormSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/DeclineRequestFormSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms
+
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.DeclineRequestFieldName
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.client.DeclineRequestForm
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+
+class DeclineRequestFormSpec extends ViewSpecSupport:
+
+  "The decline request form" should:
+
+    val form = DeclineRequestForm.form("Agent Name")
+
+    "bind successfully" when:
+
+      "the value is true" in:
+        form.bind(Map(DeclineRequestFieldName -> "true")).hasErrors shouldBe false
+
+      "the value is false" in:
+        form.bind(Map(DeclineRequestFieldName -> "false")).hasErrors shouldBe false
+
+    "fail to bind an empty value and return the expected message key and message args" in:
+      val agentForm = DeclineRequestForm.form("Agent Name")
+      val result = agentForm.bind(Map(DeclineRequestFieldName -> ""))
+      result.hasErrors shouldBe true
+      result.errors.head.message shouldBe "confirmDecline.error.required"
+      result.errors.head.args shouldBe Seq("Agent Name")

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
@@ -25,33 +25,33 @@ class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matcher
 
   val serviceNames: List[String] = List(incomeTax, vat, capitalGainsTaxUkProperty, plasticPackagingTax, pillar2, trustsAndEstates, trustsAndEstateNonTaxable, incomeRecordViewer, countryByCountryReporting)
 
-  "getServiceKeys" should {
-      s"return enrolments supported by $incomeTax" in {
-        services.getServiceKeysForUrlPart(incomeTax) shouldBe Set(HMRCMTDIT, HMRCNI, HMRCPT)
-      }
-      s"return enrolments supported by $vat" in {
-        services.getServiceKeysForUrlPart(vat) shouldBe Set(HMRCMTDVAT)
-      }
-      s"return enrolments supported by $capitalGainsTaxUkProperty" in {
+  "getServiceKeysForUrlPart" should {
+    s"return enrolments supported by $incomeTax" in {
+      services.getServiceKeysForUrlPart(incomeTax) shouldBe Set(HMRCMTDIT, HMRCNI, HMRCPT)
+    }
+    s"return enrolments supported by $vat" in {
+      services.getServiceKeysForUrlPart(vat) shouldBe Set(HMRCMTDVAT)
+    }
+    s"return enrolments supported by $capitalGainsTaxUkProperty" in {
       services.getServiceKeysForUrlPart(capitalGainsTaxUkProperty) shouldBe Set(HMRCCGTPD)
-      }
-      s"return enrolments supported by $trustsAndEstates" in {
+    }
+    s"return enrolments supported by $trustsAndEstates" in {
       services.getServiceKeysForUrlPart(trustsAndEstates) shouldBe Set(HMRCTERSORG, HMRCTERSNTORG)
-      }
-      s"return enrolments supported by $pillar2" in {
-        services.getServiceKeysForUrlPart(pillar2) shouldBe Set(HMRCPILLAR2ORG)
-      }
-      s"return enrolments supported by $incomeRecordViewer" in {
+    }
+    s"return enrolments supported by $pillar2" in {
+      services.getServiceKeysForUrlPart(pillar2) shouldBe Set(HMRCPILLAR2ORG)
+    }
+    s"return enrolments supported by $incomeRecordViewer" in {
       services.getServiceKeysForUrlPart(incomeRecordViewer) shouldBe Set(HMRCNI, HMRCPT)
-      }
-      s"return enrolments supported by $plasticPackagingTax" in {
+    }
+    s"return enrolments supported by $plasticPackagingTax" in {
       services.getServiceKeysForUrlPart(plasticPackagingTax) shouldBe Set(HMRCPPTORG)
-      }
-      s"return enrolments supported by $countryByCountryReporting" in {
+    }
+    s"return enrolments supported by $countryByCountryReporting" in {
       services.getServiceKeysForUrlPart(countryByCountryReporting) shouldBe Set(HMRCCBCORG, HMRCCBCNONUKORG)
-     }
-      "throw runtime exception when service is unknown" in {
-        intercept[RuntimeException](services.getServiceKeysForUrlPart("unknown"))
+    }
+    "return an empty Set when service is unknown" in {
+      services.getServiceKeysForUrlPart("unknown") shouldBe Set()
     }
   }
   "inferredClientType" should {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/AuthoriseAgentStartPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/AuthoriseAgentStartPageSpec.scala
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentclientrelationshipsfrontend.views.journey
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.client
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.routes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
-import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.journey.AuthoriseAgentStartPage
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.AuthoriseAgentStartPage
 
 import scala.language.postfixOps
 
@@ -55,7 +56,6 @@ class AuthoriseAgentStartPageSpec extends ViewSpecSupport {
 
   "AuthoriseAgentStartPage for authorisation journey view" should {
 
-
     val uid = "uid"
     for (taxService <- taxServiceNames.keySet.toList) {
       val view: HtmlFormat.Appendable = viewTemplate(agentName, taxService, uid)
@@ -75,15 +75,10 @@ class AuthoriseAgentStartPageSpec extends ViewSpecSupport {
         val expectedUrl = s"/agent-client-relationships/authorisation-response/$uid/$taxService/consent-information"
         doc.mainContent.extractLinkButton(1).value shouldBe TestLink("Start now", expectedUrl)
       }
-      s"have correct link for $taxService" in {
-        val expectedUrl = s"/agent-client-relationships/authorisation-response/$uid/$taxService/decline-request"
+      s"have correct 'Decline' link for $taxService" in {
+        val expectedUrl = routes.DeclineRequestController.show(uid, taxService).url
         doc.mainContent.extractLink(1).value shouldBe TestLink(s"I do not want $agentName to act for me.", expectedUrl)
       }
-
-
     }
-
   }
-
-
 }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/DeclineRequestPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/DeclineRequestPageSpec.scala
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.client
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.client.DeclineRequestForm
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{ClientJourney, ClientJourneyRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.DeclineRequestPage
+
+class DeclineRequestPageSpec extends ViewSpecSupport:
+
+  val viewTemplate: DeclineRequestPage = app.injector.instanceOf[DeclineRequestPage]
+  val newAgentName = "ABC Agents"
+  val mainRole = "mainAgent"
+  val suppRole = "suppAgent"
+  val genericRole = "agent"
+  val uid = "ABC123"
+
+  val genericRoleServices: Seq[String] = Seq(
+    "PERSONAL-INCOME-RECORD", "HMRC-MTD-VAT", "HMRC-CGT-PD",
+    "HMRC-PPT-ORG", "HMRC-CBC-ORG", "HMRC-PILLAR2-ORG", "HMRC-TERS-ORG"
+  )
+  val mainRoleServices: Seq[String] = Seq("HMRC-MTD-IT")
+  val suppRoleServices: Seq[String] = Seq("HMRC-MTD-IT-SUPP")
+
+  val serviceKeyToNameMap: Map[String, String] = Map(
+    "HMRC-MTD-IT" -> "income-tax",
+    "HMRC-MTD-IT-SUPP" -> "income-tax",
+    "PERSONAL-INCOME-RECORD" -> "income-record-viewer",
+    "HMRC-MTD-VAT" -> "vat",
+    "HMRC-CGT-PD" -> "capital-gains-tax-uk-property",
+    "HMRC-PPT-ORG" -> "plastic-packaging-tax",
+    "HMRC-CBC-ORG" -> "country-by-country-reporting",
+    "HMRC-PILLAR2-ORG" -> "pillar-2",
+    "HMRC-TERS-ORG" -> "trusts-and-estates"
+  )
+
+  val baseJourneyModel: ClientJourney = ClientJourney(
+    "authorisation-response",
+    agentName = Some(newAgentName)
+  )
+
+  object Expected:
+    val title = "Decline a request - Appoint someone to deal with HMRC for you - GOV.UK"
+    val heading = "Decline a request"
+    def caption(service: String): String = messages(service)
+    def introductionParagraph(role: String, service: String): String =
+      s"$newAgentName want to be your ${messages(s"confirmDecline.$role")} for ${messages(service)}."
+    val guidanceParagraph =
+      "Read the guidance about the difference between main agents and supporting agents (opens in a new tab)."
+    def ifYouDeclineParagraph(role: String, service: String): String =
+      s"If you decline the request from $newAgentName, they will not be able to act as your " +
+        s"${messages(s"confirmDecline.$role")} for ${messages(service)}."
+    val changeYourMindParagraph = "You can change your mind later - just ask them to send you another request."
+    val formLegend = s"Do you want to decline the request from $newAgentName?"
+    val yesOption = "Yes"
+    val noOption = "No, I want to consider this request"
+    def formError(service: String): String = s"Error: Select 'yes' if you want to decline the request from $newAgentName"
+    val continue = "Continue"
+
+  "The Decline Request page" when:
+
+    "the request is for a tax type that does not allow for main/supporting agents" should:
+
+      genericRoleServices.foreach: service =>
+
+        s"the tax service is $service" should:
+
+          val form = DeclineRequestForm.form(newAgentName)
+          implicit val journeyRequest: ClientJourneyRequest[?] =
+            ClientJourneyRequest(baseJourneyModel.copy(serviceKey = Some(service)), request)
+          val view = viewTemplate(form, genericRole, uid, serviceKeyToNameMap(service))
+          val doc: Document = Jsoup.parse(view.body)
+
+          "have the correct title" in:
+            doc.title() shouldBe Expected.title
+
+          "have the correct heading" in:
+            doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+
+          "have the correct caption" in:
+            doc.mainContent.extractText(h2, 1).value shouldBe Expected.caption(service)
+
+          "have the correct first paragraph" in:
+            doc.mainContent.extractText(p, 1).value shouldBe Expected.introductionParagraph(genericRole, service)
+
+          "not have the agent role guidance paragraph" in:
+            doc.mainContent.extractText("#agent-role-guidance", 1) shouldBe None
+
+          "have the correct second paragraph" in:
+            doc.mainContent.extractText(p, 2).value shouldBe Expected.ifYouDeclineParagraph(genericRole, service)
+
+          "have the correct third paragraph" in:
+            doc.mainContent.extractText(p, 3).value shouldBe Expected.changeYourMindParagraph
+
+          "have the correct radio group form" in:
+            val expectedRadioGroup = TestRadioGroup(
+              Expected.formLegend,
+              List(
+                Expected.yesOption -> "true",
+                Expected.noOption -> "false"
+              ),
+              None
+            )
+            doc.mainContent.extractRadios().value shouldBe expectedRadioGroup
+
+          "have the correct button" in:
+            doc.mainContent.extractText(".govuk-button", 1).value shouldBe Expected.continue
+
+    "the request is for a main agent" should:
+
+      mainRoleServices.foreach: service =>
+
+        s"the tax service is $service" should :
+
+          val form = DeclineRequestForm.form(newAgentName)
+          implicit val journeyRequest: ClientJourneyRequest[?] =
+            ClientJourneyRequest(baseJourneyModel.copy(serviceKey = Some(service)), request)
+          val view = viewTemplate(form, mainRole, uid, serviceKeyToNameMap(service))
+          val doc: Document = Jsoup.parse(view.body)
+
+          "have the correct title" in :
+            doc.title() shouldBe Expected.title
+
+          "have the correct heading" in :
+            doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+
+          "have the correct caption" in :
+            doc.mainContent.extractText(h2, 1).value shouldBe Expected.caption(service)
+
+          "have the correct first paragraph" in :
+            doc.mainContent.extractText(p, 1).value shouldBe Expected.introductionParagraph(mainRole, service)
+
+          "have the agent role guidance paragraph" in :
+            doc.mainContent.extractText("#agent-role-guidance", 1).value shouldBe Expected.guidanceParagraph
+
+          "have the correct third paragraph" in :
+            doc.mainContent.extractText(p, 3).value shouldBe Expected.ifYouDeclineParagraph(mainRole, service)
+
+          "have the correct fourth paragraph" in :
+            doc.mainContent.extractText(p, 4).value shouldBe Expected.changeYourMindParagraph
+
+          "have the correct radio group form" in :
+            val expectedRadioGroup = TestRadioGroup(
+              Expected.formLegend,
+              List(
+                Expected.yesOption -> "true",
+                Expected.noOption -> "false"
+              ),
+              None
+            )
+            doc.mainContent.extractRadios().value shouldBe expectedRadioGroup
+
+          "have the correct button" in :
+            doc.mainContent.extractText(".govuk-button", 1).value shouldBe Expected.continue
+
+    "the request is for a supporting agent" should :
+
+      suppRoleServices.foreach: service =>
+
+        s"the tax service is $service" should :
+
+          val form = DeclineRequestForm.form(newAgentName)
+          implicit val journeyRequest: ClientJourneyRequest[?] =
+            ClientJourneyRequest(baseJourneyModel.copy(serviceKey = Some(service)), request)
+          val view = viewTemplate(form, suppRole, uid, serviceKeyToNameMap(service))
+          val doc: Document = Jsoup.parse(view.body)
+
+          "have the correct title" in :
+            doc.title() shouldBe Expected.title
+
+          "have the correct heading" in :
+            doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+
+          "have the correct caption" in :
+            doc.mainContent.extractText(h2, 1).value shouldBe Expected.caption(service)
+
+          "have the correct first paragraph" in :
+            doc.mainContent.extractText(p, 1).value shouldBe Expected.introductionParagraph(suppRole, service)
+
+          "have the agent role guidance paragraph" in :
+            doc.mainContent.extractText("#agent-role-guidance", 1).value shouldBe Expected.guidanceParagraph
+
+          "have the correct third paragraph" in :
+            doc.mainContent.extractText(p, 3).value shouldBe Expected.ifYouDeclineParagraph(suppRole, service)
+
+          "have the correct fourth paragraph" in :
+            doc.mainContent.extractText(p, 4).value shouldBe Expected.changeYourMindParagraph
+
+          "have the correct radio group form" in :
+            val expectedRadioGroup = TestRadioGroup(
+              Expected.formLegend,
+              List(
+                Expected.yesOption -> "true",
+                Expected.noOption -> "false"
+              ),
+              None
+            )
+            doc.mainContent.extractRadios().value shouldBe expectedRadioGroup
+
+          "have the correct button" in :
+            doc.mainContent.extractText(".govuk-button", 1).value shouldBe Expected.continue
+
+    "there are errors in the form" should:
+
+      val form = DeclineRequestForm.form(newAgentName).bind(Map())
+      implicit val journeyRequest: ClientJourneyRequest[?] =
+        ClientJourneyRequest(baseJourneyModel.copy(serviceKey = Some("HMRC-MTD-VAT")), request)
+      val view = viewTemplate(form, genericRole, uid, serviceKeyToNameMap("HMRC-MTD-VAT"))
+      val doc: Document = Jsoup.parse(view.body)
+
+      "have the correct error message" in:
+        doc.mainContent.extractText(".govuk-error-message", 1).value shouldBe Expected.formError(newAgentName)


### PR DESCRIPTION
A few notes in addition to the main work:

- Moved `AuthoriseAgentStartPage` to the `client` dir as it's a part of the client journey
- Removed exception throwing from `ClientServiceConfigurationService.getServiceKeysForUrlPart`, which allows for auth actions to handle scenarios of invalid URL parts appropriately
- Removed the `validateUrlPart` func and if statement from `ConsentInformationController`, as the else case was impossible to hit due to auth action redirecting in this scenario