### PR TITLE
APB-9217 MYTA template, routes and controller

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
@@ -45,6 +45,7 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration)
   val guidanceAuthoriseAgent = s"$govUkUrl/guidance/authorise-an-agent-to-deal-with-certain-tax-services-for-you"
   val privacyPolicyUrl = s"$govUkUrl/government/publications/data-protection-act-dpa-information-hm-revenue-and-customs-hold-about-you/data-protection-act-dpa-information-hm-revenue-and-customs-hold-about-you"
   val signupClientUrl: String = s"$govUkUrl/guidance/sign-up-your-client-for-making-tax-digital-for-income-tax"
+  val mytaOtherTaxServicesGuidanceUrl: String = s"$govUkUrl/guidance/client-authorisation-an-overview#how-to-change-or-cancel-authorisations-as-an-agent"
 
   // Feature Flags
   val welshLanguageSupportEnabled: Boolean = config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
@@ -22,6 +22,7 @@ import play.api.libs.ws.JsonBodyWritables.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.AgentRequest
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ManageYourTaxAgentsData
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.invitationLink.{ValidateLinkPartsError, ValidateLinkPartsResponse}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientServiceConfigurationService
@@ -153,3 +154,8 @@ class AgentClientRelationshipsConnector @Inject()(appConfig: AppConfig,
         case status => throw new Exception(s"Unexpected status $status received when fetching invitation")
       })
   }
+
+  def getManageYourTaxAgentsData()(implicit hc: HeaderCarrier): Future[ManageYourTaxAgentsData] =
+    httpV2
+      .get(url"$agentClientRelationshipsUrl/client/authorisations-relationships")
+      .execute[ManageYourTaxAgentsData]

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import com.google.inject.Inject
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.Actions
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.AuthorisationsCache
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.{AuthorisationsCacheService, ClientServiceConfigurationService}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ManageYourTaxAgentsPage
+import uk.gov.hmrc.mongo.cache.DataKey
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ManageYourTaxAgentsController @Inject()(agentClientRelationshipsConnector: AgentClientRelationshipsConnector,
+                                              serviceConfigurationService: ClientServiceConfigurationService,
+                                              mytaPage: ManageYourTaxAgentsPage,
+                                              authorisationsCacheService: AuthorisationsCacheService,
+                                              actions: Actions,
+                                              mcc: MessagesControllerComponents
+                                             )(implicit val executionContext: ExecutionContext, appConfig: AppConfig)
+  extends FrontendController(mcc) with I18nSupport:
+
+  def show: Action[AnyContent] = actions.clientAuthenticate.async:
+    implicit request =>
+      for {
+        mytaData <- agentClientRelationshipsConnector.getManageYourTaxAgentsData()
+        _ <- authorisationsCacheService
+          .put[AuthorisationsCache](DataKey("authorisationsCache"), AuthorisationsCache(
+            authorisations = Seq(mytaData.agentsAuthorisations.agentsAuthorisations).flatten.flatMap(_.authorisations))
+          )
+      } yield Ok(mytaPage(serviceConfigurationService.allSupportedServices.map(s => (s, serviceConfigurationService.getUrlPart(s))).toMap, mytaData))
+
+

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/client/ManageYourTaxAgentsData.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/client/ManageYourTaxAgentsData.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.client
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.Invitation
+
+import java.time.LocalDate
+
+case class ManageYourTaxAgentsData(
+                                    agentsInvitations: AgentsInvitationsResponse,
+                                    agentsAuthorisations: AgentsAuthorisationsResponse,
+                                    authorisationEvents: AuthorisationEventsResponse
+                    )
+object ManageYourTaxAgentsData {
+  implicit val format: OFormat[ManageYourTaxAgentsData] = Json.format[ManageYourTaxAgentsData]
+}
+
+case class AgentsInvitationsResponse(agentsInvitations: Seq[AgentData])
+
+object AgentsInvitationsResponse {
+  implicit val format: OFormat[AgentsInvitationsResponse] = Json.format[AgentsInvitationsResponse]
+}
+
+case class AgentsAuthorisationsResponse(agentsAuthorisations: Seq[AuthorisedAgent])
+
+object AgentsAuthorisationsResponse {
+  implicit val format: OFormat[AgentsAuthorisationsResponse] = Json.format[AgentsAuthorisationsResponse]
+}
+
+case class AuthorisationEventsResponse(authorisationEvents: Seq[AuthorisationEvent])
+
+object AuthorisationEventsResponse {
+  implicit val format: OFormat[AuthorisationEventsResponse] = Json.format[AuthorisationEventsResponse]
+}
+
+case class AgentData(uid: String, agentName: String, invitations: Seq[Invitation])
+
+object AgentData {
+  implicit val format: OFormat[AgentData] = Json.format[AgentData]
+}
+
+case class AuthorisedAgent(agentName: String, arn: String, authorisations: Seq[Authorisation])
+
+object AuthorisedAgent {
+  implicit val format: OFormat[AuthorisedAgent] = Json.format[AuthorisedAgent]
+}
+
+case class Authorisation(id: String, service: String, clientId: String, date: LocalDate, arn: String, agentName: String)
+
+object Authorisation {
+  implicit val format: OFormat[Authorisation] = Json.format[Authorisation]
+}
+
+case class AuthorisationEvent(agentName: String, service: String, date: LocalDate, eventType: InvitationStatus)
+
+object AuthorisationEvent {
+  implicit val format: OFormat[AuthorisationEvent] = Json.format[AuthorisationEvent]
+}
+
+case class AuthorisationsCache(authorisations: Seq[Authorisation])
+
+object AuthorisationsCache {
+  implicit val format: OFormat[AuthorisationsCache] = Json.format[AuthorisationsCache]
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/AuthorisationsCacheRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/AuthorisationsCacheRepository.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.repositories
+
+import uk.gov.hmrc.http.SessionKeys
+import uk.gov.hmrc.mongo.cache.SessionCacheRepository
+import uk.gov.hmrc.mongo.{CurrentTimestampSupport, MongoComponent}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
+
+@Singleton
+class AuthorisationsCacheRepository @Inject()(mongo: MongoComponent)(implicit ec: ExecutionContext)
+  extends SessionCacheRepository(
+    mongoComponent = mongo,
+    collectionName = "authorised-agents-cache",
+    ttl = 15.minutes,
+    timestampSupport = new CurrentTimestampSupport(),
+    sessionIdKey = SessionKeys.sessionId
+  )

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.services
 
 import uk.gov.hmrc.agentclientrelationshipsfrontend.actions.AgentRequest
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ManageYourTaxAgentsData
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{AgentDetails, AuthorisationRequestInfo, AuthorisationRequestInfoForClient, ClientDetailsResponse}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyRequest, ClientJourneyRequest}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -56,6 +57,10 @@ class AgentClientRelationshipsService @Inject()(agentClientRelationshipsConnecto
 
   def agentCancelInvitation(invitationId: String)(implicit hc: HeaderCarrier, request: AgentRequest[?]): Future[Unit] = {
     agentClientRelationshipsConnector.cancelInvitation(invitationId)
+  }
+
+  def getManageYourTaxAgentsData()(implicit hc: HeaderCarrier): Future[ManageYourTaxAgentsData] = {
+    agentClientRelationshipsConnector.getManageYourTaxAgentsData()
   }
 
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AuthorisationsCacheService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AuthorisationsCacheService.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.services
+
+import play.api.libs.json.{Reads, Writes}
+import play.api.mvc.Request
+import uk.gov.hmrc.agentclientrelationshipsfrontend.repositories.AuthorisationsCacheRepository
+import uk.gov.hmrc.mongo.cache.DataKey
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+
+@Singleton
+class AuthorisationsCacheService @Inject()(sessionCacheRepository: AuthorisationsCacheRepository) {
+
+  def get[T](dataKey: DataKey[T])
+            (implicit reads: Reads[T], request: Request[?]): Future[Option[T]] = {
+        sessionCacheRepository.getFromSession(dataKey)
+  }
+
+  def put[T](dataKey: DataKey[T], value: T)
+            (implicit writes: Writes[T], request: Request[?]): Future[(String, String)] = {
+        sessionCacheRepository.putSession(dataKey, value)
+  }
+
+  def delete[T](dataKey: DataKey[T])
+               (implicit request: Request[?]): Future[Unit] = {
+    sessionCacheRepository.deleteFromSession(dataKey)
+  }
+
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/Layout.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
-@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.layouts.SidebarLayout
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.layouts.FullWidthLayout
 
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardPage
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers._
@@ -34,7 +34,8 @@
         autocompleteJavascript: HmrcAccessibleAutocompleteJavascript,
         hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper,
         hmrcReportTechnicalIssueHelper: HmrcReportTechnicalIssueHelper,
-        twoThirdsOneThirdMainContent: SidebarLayout
+        fullWidthLayout: FullWidthLayout,
+        twoThirdsMainContent: TwoThirdsMainContent
 )
 
 @(
@@ -42,8 +43,8 @@
         serviceName: Option[String] = None,
         optionalForm: Option[Form[?]] = None,
         backLinkHref: Option[String] = None,
-        sidebar: Option[Html] = None,
-        suppressBackLink: Boolean = false
+        suppressBackLink: Boolean = false,
+        fullWidth: Boolean = false
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @isSignedIn  = @{request.session.get("authToken").isDefined}
@@ -66,9 +67,10 @@
 }
 @* instead of doing title building at template level we can centralise it here and for
 form submission pages we can pass in hasErrors = form.hasErrors, the required pageTitle should always
-equal the page heading (H1) content *@
+equal the page heading (H1) content, if they are identical then only the service name *@
+@pageAndServiceTitle = @{if(pageTitle == service) service else s"$pageTitle - $service"}
 @gdsTitle = @{
-    s"""${if(optionalForm.exists(_.hasErrors)){ s"""${messages("error.prefix")} """ } else ""}$pageTitle - $service - GOV.UK"""
+    s"""${if(optionalForm.exists(_.hasErrors)){ s"""${messages("error.prefix")} """ } else ""}$pageAndServiceTitle - GOV.UK"""
 }
 
 @scripts = {
@@ -102,14 +104,10 @@ equal the page heading (H1) content *@
         templateOverrides = TemplateOverrides(
             additionalHeadBlock = Some(head),
             additionalScriptsBlock = Some(scripts),
-            mainContentLayout = sidebar.map(s => twoThirdsOneThirdMainContent(s, pageTitle))
+            mainContentLayout = if(fullWidth) Some(fullWidthLayout(_)) else Some(twoThirdsMainContent(_))
         ),
         isWelshTranslationAvailable = appConfig.welshLanguageSupportEnabled,
         backLink = if suppressBackLink then None else Some(backLinkHref.map(BackLink(_, messages("button.back"))).getOrElse(BackLink.mimicsBrowserBackButtonViaJavaScript)),
         serviceName = Some(service)
   )
 )(content)
-
-@{
-    //$COVERAGE-OFF$
-}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TrackRequestsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TrackRequestsPage.scala.html
@@ -83,7 +83,7 @@
     filters.map(filter => if(filter == "PartialAuth") "Accepted" else filter).distinct
 }
 
-@sidebarContent = {
+@filterContent = {
 
     @if(result.totalResults > appConfig.trackRequestsPageSize || result.filtersApplied.nonEmpty) {
         <div class="govuk-!-width-two-thirds">
@@ -132,7 +132,9 @@
     }
 }
 
-@layout(pageTitle, sidebar = Some(sidebarContent)) {
+@layout(pageTitle, fullWidth = true) {
+    <h1 class="govuk-heading-xl">@pageTitle</h1>
+    @filterContent
     @if(result.requests.nonEmpty) {
         @govukTable(Table(
             head = Some(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPage.scala.html
@@ -60,7 +60,7 @@
   <p class="govuk-body">@Html(messages(s"$key.section1.p4", appConfig.privacyPolicyUrl))</p>
 
   <h2 class="govuk-heading-l">@messages(s"$key.section2.h2")</h2>
-  <p class="govuk-body">@Html(messages(s"$key.section2.p1", "routes.MYTAController.show()"))</p>
+  <p class="govuk-body">@Html(messages(s"$key.section2.p1", appConfig.acmExternalUrl))</p>
 
   <h2 class="govuk-heading-l">@messages(s"$key.section3.h2")</h2>
   <p class="govuk-body">@Html(messages(s"$key.section3.p1", indefiniteAgentRole, taxServiceName))</p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
@@ -1,0 +1,163 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ManageYourTaxAgentsData
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcNewTabLinkHelper
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.newtablinkhelper.NewTabLinkHelper
+@import java.time.format.DateTimeFormatter
+@import java.time.{Instant, LocalDate, ZoneOffset}
+@import java.util.Locale
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.routes
+@import play.twirl.api.Html
+
+@this(
+        layout: Layout,
+        govukDetails: GovukDetails,
+        govukTabs: GovukTabs,
+        govukTable: GovukTable,
+        h1: h1,
+        hmrcNewTabLinkHelper: HmrcNewTabLinkHelper
+)
+
+@(supportedServices: Map[String, String], data: ManageYourTaxAgentsData)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@key = @{"manageYourTaxAgents"}
+@pageTitle = @{messages(s"$key.header")}
+@servicesList = {
+  <ul class="govuk-list govuk-list--bullet">
+   @{supportedServices.keySet.map(service =>
+    <li>{messages(service)}</li>
+   )}
+  </ul>
+  @hmrcNewTabLinkHelper(NewTabLinkHelper(
+    href = Some(appConfig.mytaOtherTaxServicesGuidanceUrl),
+    text = messages(s"$key.link")
+  ))
+ }
+@dateFormatter = @{
+    DateTimeFormatter.ofPattern("d MMMM uuuu", Locale.UK)
+}
+@agentRoleFromService(service: String) = @{
+    if(service == "HMRC-MTD-IT-SUPP") messages(s"$key.agentRole.supporting") else messages(s"$key.agentRole.main")
+}
+@linkFromService(uid: String, service: String, agentName: String) = {
+    <a href="@{routes.ConsentInformationController.show(uid, supportedServices(service)).url}" class="govuk-link">
+        @Html(messages(s"$key.currentRequests.action.link", agentName, messages(service), agentRoleFromService(service)))
+    </a>
+}
+@deAuthLink(id: String, agentName: String, service: String) = {
+    <a href="@{s"#?id=$id"}" class="govuk-link">
+        @Html(messages(s"$key.authorisedAgents.action.link", agentName, messages(service), agentRoleFromService(service)))
+    </a>
+}
+@cellClasses = @{"govuk-body-s govuk-!-width-one-quarter"}
+@currentRequests = {
+    <h2 class="govuk-heading-m">@messages(s"$key.currentRequests")</h2>
+    @data.agentsInvitations.agentsInvitations.map { agent =>
+        @govukTable(Table(
+            classes = "govuk-body-s",
+            caption = Some(agent.agentName),
+            captionClasses = "govuk-table__caption--s",
+            head = Some(Seq(
+                HeadCell(Text(messages(s"$key.currentRequests.taxService")), classes = cellClasses),
+                HeadCell(Text(messages(s"$key.currentRequests.agentRole")), classes = cellClasses),
+                HeadCell(Text(messages(s"$key.currentRequests.respondBy")), classes = cellClasses),
+                HeadCell(Text(messages(s"$key.currentRequests.action")), classes = cellClasses)
+            )),
+            rows = agent.invitations.map { request =>
+                Seq(
+                    TableRow(content = Text(messages(request.service)), classes = cellClasses),
+                    TableRow(Text(agentRoleFromService(request.service)), classes = cellClasses),
+                    TableRow(Text(request.expiryDate.format(dateFormatter)), classes = cellClasses),
+                    TableRow(HtmlContent(linkFromService(agent.uid, request.service, agent.agentName)), classes = cellClasses)
+                )
+            }
+        ))
+    }
+}
+@authorisedAgents = {
+    <h2 class="govuk-heading-m">@messages(s"$key.authorisedAgents")</h2>
+    @if(data.agentsAuthorisations.agentsAuthorisations.isEmpty) {
+        <p class="govuk-body">@messages(s"$key.authorisedAgents.empty")</p>
+    } else {
+        @data.agentsAuthorisations.agentsAuthorisations.map { agent =>
+            @govukTable(Table(
+                classes = "govuk-body-s",
+                caption = Some(agent.agentName),
+                captionClasses = "govuk-table__caption--s",
+                head = Some(Seq(
+                    HeadCell(Text(messages(s"$key.authorisedAgents.taxService")), classes = cellClasses),
+                    HeadCell(Text(messages(s"$key.authorisedAgents.agentRole")), classes = cellClasses),
+                    HeadCell(Text(messages(s"$key.authorisedAgents.consentDate")), classes = cellClasses),
+                    HeadCell(Text(messages(s"$key.authorisedAgents.action")), classes = cellClasses)
+                )),
+                rows = agent.authorisations.map { authorisation =>
+                    Seq(
+                        TableRow(content = Text(messages(authorisation.service)), classes = cellClasses),
+                        TableRow(Text(agentRoleFromService(authorisation.service)), classes = cellClasses),
+                        TableRow(Text(authorisation.date.format(dateFormatter)), classes = cellClasses),
+                        TableRow(HtmlContent(deAuthLink(authorisation.id, authorisation.service, authorisation.agentName)), classes = cellClasses)
+                    )
+                }
+            ))
+        }
+    }
+}
+@history = {
+    <h2 class="govuk-heading-m">@messages(s"$key.history")</h2>
+    @if(data.authorisationEvents.authorisationEvents.isEmpty) {
+        <p class="govuk-body">@messages(s"$key.history.empty")</p>
+    }
+}
+@currentRequestsTab = @{TabItem(
+    id = Some("currentRequests"),
+    label = messages(s"$key.currentRequests"),
+    panel = TabPanel(content = HtmlContent(currentRequests))
+)}
+@authorisedAgentsTab = @{TabItem(
+    id = Some("authorisedAgents"),
+    label = messages(s"$key.authorisedAgents"),
+    panel = TabPanel(content = HtmlContent(authorisedAgents))
+)}
+@historyTab = @{TabItem(
+    id = Some("history"),
+    label = messages(s"$key.history"),
+    panel = TabPanel(content = HtmlContent(history))
+)}
+@tabs = @{
+    if(data.agentsInvitations.agentsInvitations.isEmpty) Seq(authorisedAgentsTab, historyTab)
+    else Seq(currentRequestsTab, authorisedAgentsTab, historyTab)
+}
+
+@layout(pageTitle, Some(pageTitle), fullWidth = true) {
+    @h1(pageTitle)
+    @govukDetails(Details(summary = Text(messages(s"$key.p")), content = HtmlContent(servicesList)))
+    <h2 class="govuk-heading-l">@messages(s"$key.agentRoles.h2")</h2>
+    <p class="govuk-body">@messages(s"$key.agentRoles.p1")</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>@messages(s"$key.agentRoles.li1")</li>
+        <li>@messages(s"$key.agentRoles.li2")</li>
+    </ul>
+    <p class="govuk-body">@messages(s"$key.agentRoles.p2")</p>
+    <p class="govuk-body">
+        @hmrcNewTabLinkHelper(NewTabLinkHelper(
+            href = Some(appConfig.mytaOtherTaxServicesGuidanceUrl),
+            text = messages(s"$key.agentRoles.guidanceLink")
+        ))
+    </p>
+    @govukTabs(Tabs(items = tabs))
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/layouts/FullWidthLayout.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/layouts/FullWidthLayout.scala.html
@@ -16,10 +16,10 @@
 
 @this()
 
-@(sidebarContent: Html, pageTitle: String)(mainContent: Html)
+@(contentBlock: Html)
 
-    <div class="govuk-grid-column-full-width">
-        <h1 class="govuk-heading-xl">@pageTitle</h1>
-        @sidebarContent
-        @mainContent
-    </div>
+<div class="govuk-grid-row">
+ <div class="govuk-grid-column-full">
+ @contentBlock
+ </div>
+</div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -46,6 +46,9 @@ POST       /authorisation-response/check-answer                                 
 
 GET        /authorisation-response/confirmation                                         uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConfirmationController.show
 
+# Client Manage Your Tax Agents URLs ----------------------------------------------------------------------------------------
+GET        /manage-your-tax-agents                                                      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ManageYourTaxAgentsController.show
+
 # Agent Journey URLs ----------------------------------------------------------------------------------------------------------
 GET        /:journeyType                                                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.StartJourneyController.startJourney(journeyType: AgentJourneyType)
 

--- a/conf/messages
+++ b/conf/messages
@@ -819,6 +819,43 @@ clientConfirmation.rejected.HMRC-PILLAR2-ORG.p1=You have not given permission fo
 clientConfirmation.rejected.HMRC-TERS-ORG.p1=You have not given permission for {0} to manage a trust or an estate.
 clientConfirmation.rejected.HMRC-TERSNT-ORG.p1=You have not given permission for {0} to manage a trust or an estate.
 
+
+# ________________________________________________________________________________
+# MYTA - Manage Your Tax Agents - client content
+# ________________________________________________________________________________
+
+manageYourTaxAgents.header=Manage who can deal with HMRC for you
+manageYourTaxAgents.p=Taxes you can manage from this page
+manageYourTaxAgents.link=Read the guidance about how to view and change authorisations for other tax services
+manageYourTaxAgents.agentRoles.h2=Agent roles
+manageYourTaxAgents.agentRoles.p1=How we define ‘main’ agent:
+manageYourTaxAgents.agentRoles.li1=the main agent helping to manage your Making Tax Digital for Income Tax
+manageYourTaxAgents.agentRoles.li2=the sole agent helping to manage any other tax
+manageYourTaxAgents.agentRoles.p2=You can also have ‘supporting’ agents helping to manage your Making Tax Digital for Income Tax.
+manageYourTaxAgents.agentRoles.guidanceLink=Find out how main and supporting agents can act for you
+
+manageYourTaxAgents.agentRole.main=Main
+manageYourTaxAgents.agentRole.supporting=Supporting
+
+manageYourTaxAgents.currentRequests=Current requests
+manageYourTaxAgents.currentRequests.taxService=Tax service
+manageYourTaxAgents.currentRequests.agentRole=Agent role
+manageYourTaxAgents.currentRequests.respondBy=Respond by
+manageYourTaxAgents.currentRequests.action=What you need to do
+
+manageYourTaxAgents.authorisedAgents=Authorised agents
+manageYourTaxAgents.authorisedAgents.empty=You do not have any authorised agents.
+manageYourTaxAgents.authorisedAgents.taxService=Tax service
+manageYourTaxAgents.authorisedAgents.agentRole=Agent role
+manageYourTaxAgents.authorisedAgents.consentDate=When you gave consent
+manageYourTaxAgents.authorisedAgents.action=Action
+manageYourTaxAgents.authorisedAgents.action.link=Remove authorisation<span class="govuk-visually-hidden"> from {0} to manage your {1} as a {2} agent</span>
+
+manageYourTaxAgents.history=History
+manageYourTaxAgents.history.empty=There is no authorisation history on this account.
+
+manageYourTaxAgents.currentRequests.action.link=Respond to request<span class="govuk-visually-hidden"> from {0} to manage your {1} as a {2} agent</span>
+
 # ________________________________________________________________________________
 # Unauthorised exit partials
 # ________________________________________________________________________________

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsControllerISpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
+
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.test.Helpers.LOCATION
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.Invitation
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{AgentData, AgentsAuthorisationsResponse, AgentsInvitationsResponse, AuthorisationEventsResponse, ManageYourTaxAgentsData, Pending}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes as authRoutes
+
+import java.time.{Instant, LocalDate}
+
+class ManageYourTaxAgentsControllerISpec extends ComponentSpecHelper with AuthStubs:
+
+  val mytaData: ManageYourTaxAgentsData = ManageYourTaxAgentsData(
+    agentsInvitations = AgentsInvitationsResponse(agentsInvitations = Seq(
+      AgentData(
+        uid = "NBM9TUDA",
+        agentName = "Test Agent",
+        invitations = Seq(
+          Invitation(
+            invitationId = "1234567890",
+            service = "HMRC-MTD-IT",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = LocalDate.now().plusDays(6),
+            lastUpdated = Instant.now()
+          ),
+          Invitation(
+            invitationId = "123LD67891",
+            service = "HMRC-PILLAR2-ORG",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = LocalDate.now().plusDays(15),
+            lastUpdated = Instant.now()
+          )
+        )
+      ),
+      AgentData(
+        uid = "1234590",
+        agentName = "Test VAT Agent Ltd",
+        invitations = Seq(
+          Invitation(
+            invitationId = "123456BFX90",
+            service = "HMRC-MTD-VAT",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = LocalDate.now().plusDays(11),
+            lastUpdated = Instant.now()
+          )
+        )
+      )
+    )),
+    agentsAuthorisations = AgentsAuthorisationsResponse(agentsAuthorisations = Seq.empty),
+    authorisationEvents = AuthorisationEventsResponse(authorisationEvents = Seq.empty)
+  )
+
+  "The show action" should:
+
+    "return status 200 OK" when:
+
+      "signed in as a client" in:
+        authoriseAsClient()
+        stubGet("/agent-client-relationships/client/authorisations-relationships", OK, Json.toJson(mytaData).toString)
+        val result = get(routes.ManageYourTaxAgentsController.show.url)
+        result.status shouldBe OK
+
+    "redirect to cannot view page" when:
+
+      "signed in as an agent" in:
+        authoriseAsAgent()
+        val result = get(routes.ManageYourTaxAgentsController.show.url)
+        result.status shouldBe SEE_OTHER
+        result.header(LOCATION) shouldBe Some(authRoutes.AuthorisationController.cannotViewRequest.url)

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AuthStubs.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/AuthStubs.scala
@@ -35,7 +35,10 @@ trait AuthStubs {
           "key" -> "AgentReferenceNumber",
           "value" -> arn
         ))
-      ))
+      )),
+      "affinityGroup" -> "Agent",
+      "confidenceLevel" -> 50,
+      "allEnrolments" -> Json.arr()
     ).toString
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,6 +10,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "10.3.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % hmrcMongoVersion,
     "uk.gov.hmrc" %% "play-conditional-form-mapping-play-30" % "3.2.0",
+    "uk.gov.hmrc"       %% "crypto-json-play-30"       % "8.1.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,21 +2,21 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.0.0"
-  private val hmrcMongoVersion = "2.1.0"
+  private val bootstrapVersion = "9.9.0"
+  private val hmrcMongoVersion = "2.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "10.3.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % hmrcMongoVersion,
     "uk.gov.hmrc" %% "play-conditional-form-mapping-play-30" % "3.2.0",
-    "uk.gov.hmrc"       %% "crypto-json-play-30"       % "8.1.0"
+    "uk.gov.hmrc"       %% "crypto-json-play-30"       % "8.2.0"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion % Test,
-    "org.jsoup" % "jsoup" % "1.17.2" % Test
+    "org.jsoup" % "jsoup" % "1.19.1" % Test
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.3")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 addSbtPlugin("com.github.sbt" % "sbt-gzip" % "2.0.0")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.3")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 addSbtPlugin("com.github.sbt" % "sbt-gzip" % "2.0.0")

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/Selectors.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/Selectors.scala
@@ -67,4 +67,6 @@ trait Selectors {
   val detailsContent = ".govuk-details__text"
 
   val warning = ".govuk-warning-text"
+
+  val tabLink = ".govuk-tabs__tab"
 }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/ViewSpecHelper.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/support/ViewSpecHelper.scala
@@ -100,7 +100,7 @@ trait ViewSpecHelper extends Selectors {
       )
     }
 
-    def extractTable(index: Int = 1, numberOfCols: Int = 4): Option[TestTable] = extractByIndex(table, index).map { elem =>
+    def extractTable(index: Int, numberOfCols: Int): Option[TestTable] = extractByIndex(table, index).map { elem =>
       TestTable(
         caption = elem.select("caption").text(),
         rows = elem.select("tbody tr").toList.map { row =>

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPageSpec.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.client
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.Invitation
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{AgentData, AgentsAuthorisationsResponse, AgentsInvitationsResponse, AuthorisationEventsResponse, ManageYourTaxAgentsData, Pending}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ManageYourTaxAgentsPage
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate}
+import java.util.Locale
+import scala.language.postfixOps
+
+class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
+
+  val viewTemplate: ManageYourTaxAgentsPage = app.injector.instanceOf[ManageYourTaxAgentsPage]
+  val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM uuuu", Locale.UK)
+  val agentName: String = "ABC Accountants"
+  val agentName2: String = "DEF Accountants"
+  val invitationId: String = "AB1234567890"
+  val serviceKey: String = "HMRC-MTD-IT"
+  val status: String = "Pending"
+  val expiryDate: LocalDate = LocalDate.now().plusDays(11)
+  def agentRoleFromService(service: String): String = if (service == "HMRC-MTD-IT-SUPP") "Supporting" else "Main"
+
+  val services: Map[String, String] = Map(
+    "PERSONAL-INCOME-RECORD" -> "income-record-viewer",
+    "HMRC-MTD-IT" -> "income-tax",
+    "HMRC-PPT-ORG" -> "plastic-packaging-tax",
+    "HMRC-CGT-PD" -> "capital-gains-tax-uk-property",
+    "HMRC-CBC-ORG" -> "country-by-country-reporting",
+    "HMRC-MTD-VAT" -> "vat",
+    "HMRC-PILLAR2-ORG" -> "pillar-2",
+    "HMRC-TERS-ORG" -> "trusts-and-estates"
+  )
+
+  object Expected {
+    val heading = "Manage who can deal with HMRC for you"
+    val title = s"$heading - GOV.UK"
+    val tab1 = "Current requests"
+    val tab2 = "Authorised agents"
+    val tab3 = "History"
+  }
+
+  val taxServiceNames: Map[String, String] = Map(
+    "PERSONAL-INCOME-RECORD" -> "Income Record Viewer",
+    "HMRC-MTD-IT" -> "Making Tax Digital for Income Tax",
+    "HMRC-PPT-ORG" -> "Plastic Packaging Tax",
+    "HMRC-CGT-PD" -> "Capital Gains Tax on UK property account",
+    "HMRC-CBC-ORG" -> "Country-by-country reports",
+    "HMRC-MTD-VAT" -> "VAT",
+    "HMRC-PILLAR2-ORG" -> "Pillar 2 Top-up Taxes",
+    "HMRC-TERS-ORG" -> "Trusts and Estates"
+  )
+
+  val mytaData: ManageYourTaxAgentsData = ManageYourTaxAgentsData(
+    agentsInvitations = AgentsInvitationsResponse(agentsInvitations = Seq(
+      AgentData(
+        uid = "NBM9TUDA",
+        agentName = agentName,
+        invitations = Seq(
+          Invitation(
+            invitationId = "1234567890",
+            service = "HMRC-MTD-IT",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = expiryDate,
+            lastUpdated = Instant.now()
+          ),
+          Invitation(
+            invitationId = "123LD67891",
+            service = "HMRC-PILLAR2-ORG",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = expiryDate,
+            lastUpdated = Instant.now()
+          )
+        )
+      ),
+      AgentData(
+        uid = "1234590",
+        agentName = agentName2,
+        invitations = Seq(
+          Invitation(
+            invitationId = "123456BFX90",
+            service = "HMRC-MTD-VAT",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = expiryDate,
+            lastUpdated = Instant.now()
+          )
+        )
+      )
+    )),
+    agentsAuthorisations = AgentsAuthorisationsResponse(agentsAuthorisations = Seq.empty),
+    authorisationEvents = AuthorisationEventsResponse(authorisationEvents = Seq.empty)
+  )
+
+  "ManageYourTaxAgentsPage view with current requests" should {
+
+    val view: HtmlFormat.Appendable = viewTemplate(services, mytaData)
+    val doc: Document = Jsoup.parse(view.body)
+
+    "include the correct title" in {
+      doc.title() shouldBe Expected.title
+    }
+
+    "include the correct H1 text" in {
+      doc.mainContent.extractText(h1, 1).value shouldBe Expected.heading
+    }
+
+    "include the correct list of services" in {
+      doc.mainContent.extractList(1).sorted shouldBe taxServiceNames.values.toList.sorted
+    }
+
+    "include the correct number of tabs" in {
+      doc.mainContent.extractText(tabLink, 1).value shouldBe Expected.tab1
+      doc.mainContent.extractText(tabLink, 2).value shouldBe Expected.tab2
+      doc.mainContent.extractText(tabLink, 3).value shouldBe Expected.tab3
+    }
+
+    "include a table of current requests for each agent" in {
+      doc.mainContent.extractTable(1, 4).value shouldBe TestTable(
+        caption = agentName,
+        rows = List(
+          IndexedSeq(
+            "Making Tax Digital for Income Tax",
+            "Main",
+            expiryDate.format(dateFormatter),
+            s"Respond to request from $agentName to manage your Making Tax Digital for Income Tax as a Main agent"
+          ),
+          IndexedSeq(
+            "Pillar 2 Top-up Taxes",
+            "Main",
+            expiryDate.format(dateFormatter),
+            s"Respond to request from $agentName to manage your Pillar 2 Top-up Taxes as a Main agent"
+          )
+        ))
+      doc.mainContent.extractTable(2, 4).value shouldBe TestTable(
+        caption = agentName2,
+        rows = List(
+          IndexedSeq(
+            "VAT",
+            "Main",
+            expiryDate.format(dateFormatter),
+            s"Respond to request from $agentName2 to manage your VAT as a Main agent"
+          )
+        ))
+    }
+
+  }
+
+  "ManageYourTaxAgentsPage view without any current requests" should {
+
+    val view: HtmlFormat.Appendable = viewTemplate(services, mytaData.copy(agentsInvitations = AgentsInvitationsResponse(agentsInvitations = Seq.empty)))
+    val doc: Document = Jsoup.parse(view.body)
+
+    "include the correct number of tabs" in {
+      doc.mainContent.extractText(tabLink, 1).value shouldBe Expected.tab2
+      doc.mainContent.extractText(tabLink, 2).value shouldBe Expected.tab3
+    }
+
+  }
+
+}


### PR DESCRIPTION
Previously the application-wide Layout had supported the concept of sidebar content to supplant the existing use of full width pages, now we are clear we are to continue supporting full width content for track requests and this content (Manage your tax agents) so I have updated Layout to entertain full width settings and updated the track requests template accordingly to stop using "sidebar" nomenclature to avoid confusion.

This should be merged after the [back endpoint ](https://github.com/hmrc/agent-client-relationships/pull/360) is merged and available 