### PR TITLE
APB-9193 APB-9194 client led deauth

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/Constants.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/Constants.scala
@@ -44,5 +44,6 @@ object Constants extends ServiceConstants {
   val ConfirmCancellationFieldName = "confirmCancellation"
   val ConfirmConsentFieldName = "confirmConsent"
   val DeclineRequestFieldName = "confirmDecline"
+  val ConfirmDeauthFieldName = "clientConfirmDeauth"
 
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
@@ -65,7 +65,17 @@ class AgentClientRelationshipsConnector @Inject()(appConfig: AppConfig,
     .execute[HttpResponse].map { response =>
       response.status match {
         case NO_CONTENT => ()
-        case _ => throw new RuntimeException(s"Failed to cancel authorisation: ${response.body}")
+        case _ => throw new RuntimeException(s"Failed to cancel authorisation on behalf of agent: ${response.body}")
+      }
+    }
+
+  def clientCancelAuthorisation(clientId: String, service: String, arn: String)(implicit hc: HeaderCarrier): Future[Unit] = httpV2
+    .post(url"$agentClientRelationshipsUrl/agent/$arn/remove-authorisation")
+    .withBody(Json.obj("clientId" -> clientId, "service" -> service))
+    .execute[HttpResponse].map { response =>
+      response.status match {
+        case NO_CONTENT => Future.successful(())
+        case _ => throw new RuntimeException(s"Failed to cancel authorisation on behalf of client: ${response.body}")
       }
     }
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/client/ManageYourTaxAgentsData.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/client/ManageYourTaxAgentsData.scala
@@ -60,7 +60,7 @@ object AuthorisedAgent {
   implicit val format: OFormat[AuthorisedAgent] = Json.format[AuthorisedAgent]
 }
 
-case class Authorisation(uid: String, service: String, clientId: String, date: LocalDate, arn: String, agentName: String)
+case class Authorisation(uid: String, service: String, clientId: String, date: LocalDate, arn: String, agentName: String, deauthorised: Option[Boolean] = None)
 
 object Authorisation {
   implicit val format: OFormat[Authorisation] = Json.format[Authorisation]

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/client/ConfirmDeauthForm.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/client/ConfirmDeauthForm.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.client
+
+import play.api.data.*
+import play.api.data.Forms.*
+import play.api.i18n.Messages
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.{ConfirmConsentFieldName, ConfirmDeauthFieldName}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers.FormFieldHelper
+
+object ConfirmDeauthForm extends FormFieldHelper {
+  def form: Form[Boolean] = Form(
+    single(
+      ConfirmDeauthFieldName -> optional(boolean)
+        .verifying(mandatoryBoolean(ConfirmDeauthFieldName))
+        .transform(_.getOrElse(false), Some(_))
+    )
+  )
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentClientRelationshipsService.scala
@@ -43,6 +43,10 @@ class AgentClientRelationshipsService @Inject()(agentClientRelationshipsConnecto
     agentClientRelationshipsConnector.cancelAuthorisation(journey)
   }
 
+  def cancelAuthorisation(arn: String, clientId: String, service: String)(implicit hc: HeaderCarrier): Future[Unit] = {
+    agentClientRelationshipsConnector.clientCancelAuthorisation(clientId, service, arn)
+  }
+
   def getAuthorisationRequest(invitationId: String)(implicit hc: HeaderCarrier, request: AgentRequest[?]): Future[Option[AuthorisationRequestInfo]] = {
     agentClientRelationshipsConnector.getAuthorisationRequest(invitationId)
   }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TrackRequestsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TrackRequestsPage.scala.html
@@ -112,7 +112,7 @@
                     items = Seq(SelectItem(value = Some(""), text = messages(s"$key.sidebar.allStatuses")))
                             ++ handlePartialAuth(result.availableFilters).map(name => SelectItem(
                                 value = Some(name),
-                                text = messages(s"$key.filter-status.$name"),
+                                text = messages(s"$key.filter-status.${name.toLowerCase}"),
                                 selected = result.filtersApplied.flatMap(_.get("statusFilter")).contains(name)
                             )),
                     classes = "govuk-!-margin-bottom-4"

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmDeauthPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmDeauthPage.scala.html
@@ -1,0 +1,65 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.*
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.Authorisation
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.Layout
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+
+@this(layout: Layout,
+      govukButton: GovukButton,
+      govukRadios: GovukRadios,
+      govukWarningText: GovukWarningText,
+      govukDetails: GovukDetails,
+      formWithCSRF: FormWithCSRF)
+
+@(form: Form[Boolean], authorisation: Authorisation)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
+
+@key = @{ConfirmDeauthFieldName}
+@taxServiceName = @{messages(authorisation.service)}
+@pageTitle = @{messages(s"$key.h1")}
+@serviceName = @{messages("service.name.clients")}
+
+@layout(pageTitle, Some(serviceName), Some(form)) {
+
+    <h1 class="govuk-heading-xl">@pageTitle</h1>
+    <p class="govuk-body">@messages(s"$key.p1", authorisation.agentName, taxServiceName)</p>
+
+    @formWithCSRF(action = routes.ManageYourTaxAgentsController.submitDeauth(authorisation.uid)) {
+        @govukRadios(Radios(
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(messages(s"$key.legend", authorisation.agentName)),
+                    isPageHeading = false,
+                    classes = "govuk-fieldset__legend--m"
+                ))
+            )),
+            items = Seq("true", "false").map(trueOrFalse =>
+                RadioItem(
+                    content = Text(messages(s"$key.$trueOrFalse")),
+                    value = Some(trueOrFalse)
+                )
+            )
+        ).withFormField(form(ConfirmDeauthFieldName)))
+
+        @govukButton(Button(
+            id = Some("continueButton"),
+            content = Text(messages("continue.button"))
+        ))
+    }
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationOfDeauthPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationOfDeauthPage.scala.html
@@ -1,0 +1,61 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.Layout
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.{routes => clientRoutes}
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.Authorisation
+
+@this(
+        layout: Layout,
+        govukPanel: GovukPanel
+)
+
+@(authorisation: Authorisation)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
+
+@key = @{"clientDeauthConfirmed"}
+@agentName = @{authorisation.agentName}
+@serviceKey = @{authorisation.service}
+@pageTitle = @{messages(s"$key.h1")}
+
+@layout(
+    pageTitle = pageTitle,
+    serviceName = Some(messages("manageYourTaxAgents.header")),
+    suppressBackLink = true
+) {
+
+    @govukPanel(Panel(title = Text(pageTitle)))
+
+    <h2 class="govuk-heading-m">@messages(s"$key.h2")</h2>
+    <p class="govuk-body">@messages(s"$key.p1", agentName, messages(serviceKey))</p>
+    <p class="govuk-body">@messages(s"$key.p2", agentName)</p>
+
+    @if(messages.isDefinedAt(s"$key.$serviceKey.h2")) {
+        <h2 class="govuk-heading-m">@messages(s"$key.$serviceKey.h2", agentName)</h2>
+        <p class="govuk-body">@Html(messages(s"$key.$serviceKey.p1", agentName, messages(serviceKey)))</p>
+        <p class="govuk-body">@Html(messages(s"$key.$serviceKey.p2", appConfig.mytaOtherTaxServicesGuidanceUrl))</p>
+    }
+
+    <p class="govuk-body">
+        <a href="@{clientRoutes.ManageYourTaxAgentsController.show.url}" class="govuk-link">@messages(s"$key.link")</a>
+    </p>
+
+    <p class="govuk-body">
+        <a class="govuk-link" href="@{routes.SignOutController.signOut.url}">@messages(s"$key.signOutLink")</a>
+    </p>
+    
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
@@ -38,9 +38,9 @@
 @pageTitle = @{messages(s"$key.header")}
 @servicesList = {
   <ul class="govuk-list govuk-list--bullet">
-   @{supportedServices.keySet.map(service =>
-    <li>{messages(service)}</li>
-   )}
+   @{supportedServices.keySet.map(service => messages(service)).toList.sorted.map { serviceName =>
+    <li>{serviceName}</li>
+   }}
   </ul>
   @hmrcNewTabLinkHelper(NewTabLinkHelper(
     href = Some(appConfig.mytaOtherTaxServicesGuidanceUrl),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
@@ -59,14 +59,14 @@
     </a>
 }
 @deAuthLink(id: String, agentName: String, service: String) = {
-    <a href="@{s"routes.DeauthorisationController.show($id)"}" class="govuk-link">
+    <a href="@{routes.ManageYourTaxAgentsController.showConfirmDeauth(id)}" class="govuk-link">
         @Html(messages(s"$key.authorisedAgents.action.link", agentName, messages(service), agentRoleFromService(service)))
     </a>
 }
 @cellClasses = @{"govuk-body-s govuk-!-width-one-quarter"}
 @currentRequests = {
     <h2 class="govuk-heading-m">@messages(s"$key.currentRequests")</h2>
-    @data.agentsInvitations.agentsInvitations.map { agent =>
+    @data.agentsInvitations.agentsInvitations.sortBy(_.agentName).map { agent =>
         @govukTable(Table(
             classes = "govuk-body-s",
             caption = Some(agent.agentName),
@@ -77,7 +77,7 @@
                 HeadCell(Text(messages(s"$key.currentRequests.respondBy")), classes = cellClasses),
                 HeadCell(Text(messages(s"$key.currentRequests.action")), classes = cellClasses)
             )),
-            rows = agent.invitations.map { request =>
+            rows = agent.invitations.sortBy(_.expiryDate).map { request =>
                 Seq(
                     TableRow(content = Text(messages(request.service)), classes = cellClasses),
                     TableRow(Text(agentRoleFromService(request.service)), classes = cellClasses),
@@ -93,7 +93,7 @@
     @if(data.agentsAuthorisations.agentsAuthorisations.isEmpty) {
         <p class="govuk-body">@messages(s"$key.authorisedAgents.empty")</p>
     } else {
-        @data.agentsAuthorisations.agentsAuthorisations.map { agent =>
+        @data.agentsAuthorisations.agentsAuthorisations.sortBy(_.agentName).map { agent =>
             @govukTable(Table(
                 classes = "govuk-body-s",
                 caption = Some(agent.agentName),
@@ -104,7 +104,7 @@
                     HeadCell(Text(messages(s"$key.authorisedAgents.consentDate")), classes = cellClasses),
                     HeadCell(Text(messages(s"$key.authorisedAgents.action")), classes = cellClasses)
                 )),
-                rows = agent.authorisations.map { authorisation =>
+                rows = agent.authorisations.sortBy(_.date).reverse.map { authorisation =>
                     Seq(
                         TableRow(content = Text(messages(authorisation.service)), classes = cellClasses),
                         TableRow(Text(agentRoleFromService(authorisation.service)), classes = cellClasses),
@@ -130,7 +130,7 @@
                 HeadCell(Text(messages(s"$key.history.taxService")), classes = cellClasses),
                 HeadCell(Text(messages(s"$key.history.activity")), classes = cellClasses)
             )),
-            rows = data.authorisationEvents.authorisationEvents.map { event =>
+            rows = data.authorisationEvents.authorisationEvents.sortBy(_.date).reverse.map { event =>
                 Seq(
                     TableRow(content = Text(event.date.format(dateFormatter)), classes = cellClasses),
                     TableRow(Text(messages(event.service)), classes = cellClasses),
@@ -163,14 +163,14 @@
 @layout(pageTitle, Some(pageTitle), fullWidth = true) {
     @h1(pageTitle)
     @govukDetails(Details(summary = Text(messages(s"$key.p")), content = HtmlContent(servicesList)))
-    <h2 class="govuk-heading-l">@messages(s"$key.agentRoles.h2")</h2>
+    <h2 class="govuk-heading-m">@messages(s"$key.agentRoles.h2")</h2>
     <p class="govuk-body">@messages(s"$key.agentRoles.p1")</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>@messages(s"$key.agentRoles.li1")</li>
         <li>@messages(s"$key.agentRoles.li2")</li>
     </ul>
     <p class="govuk-body">@messages(s"$key.agentRoles.p2")</p>
-    <p class="govuk-body">
+    <p class="govuk-body govuk-!-margin-bottom-7">
         @hmrcNewTabLinkHelper(NewTabLinkHelper(
             href = Some(appConfig.mytaOtherTaxServicesGuidanceUrl),
             text = messages(s"$key.agentRoles.guidanceLink")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -48,6 +48,9 @@ GET        /authorisation-response/confirmation                                 
 
 # Client Manage Your Tax Agents URLs ----------------------------------------------------------------------------------------
 GET        /manage-your-tax-agents                                                      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ManageYourTaxAgentsController.show
+GET        /manage-your-tax-agents/remove-authorisation/:id                             uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ManageYourTaxAgentsController.showConfirmDeauth(id: String)
+POST       /manage-your-tax-agents/remove-authorisation/:id                             uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ManageYourTaxAgentsController.submitDeauth(id: String)
+GET        /manage-your-tax-agents/confirmation/:id                                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ManageYourTaxAgentsController.deauthComplete(id: String)
 
 # Agent Journey URLs ----------------------------------------------------------------------------------------------------------
 GET        /:journeyType                                                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.StartJourneyController.startJourney(journeyType: AgentJourneyType)

--- a/conf/messages
+++ b/conf/messages
@@ -424,13 +424,13 @@ trackRequests.sidebar.allStatuses=All statuses
 trackRequests.filter-status.selectAll=Select all
 trackRequests.filter-status.ExpireInNext5Days=Expire in the next 5 days
 trackRequests.filter-status.ActivityWithinLast5Days=Activity within the last 5 days
-trackRequests.filter-status.Pending=Client has not yet responded
-trackRequests.filter-status.DeAuthorised=Authorisation has been removed
-trackRequests.filter-status.Rejected=Declined by client
-trackRequests.filter-status.Accepted=Accepted by client
-trackRequests.filter-status.PartialAuth=Accepted by client
-trackRequests.filter-status.Cancelled=Cancelled by you
-trackRequests.filter-status.Expired=Request expired as client did not respond in time
+trackRequests.filter-status.pending=Client has not yet responded
+trackRequests.filter-status.deauthorised=Authorisation has been removed
+trackRequests.filter-status.rejected=Declined by client
+trackRequests.filter-status.accepted=Accepted by client
+trackRequests.filter-status.partialauth=Accepted by client
+trackRequests.filter-status.cancelled=Cancelled by you
+trackRequests.filter-status.expired=Request expired as client did not respond in time
 trackRequests.filter-status.ClientCancelledAuthorisation=Accepted by client. They later cancelled their authorisation
 trackRequests.filter-status.HMRCCancelledAuthorisation=Accepted by client. HMRC later cancelled your authorisation
 trackRequests.filter-status.Declined.HMRC-CBC={0} request to manage the client’s country-by-country reports was declined.
@@ -782,7 +782,7 @@ checkYourAnswer.acceptAndSend.button=Accept and send
 checkYourAnswer.change=Change
 
 # ________________________________________________________________________________
-# Client confirmation page
+# Client confirmation of authorisation page
 # ________________________________________________________________________________
 
 clientConfirmation.accepted.h1=You have authorised {0}
@@ -865,6 +865,31 @@ manageYourTaxAgents.history.Expired.activity=The request from {0} to be your {1}
 manageYourTaxAgents.history.Cancelled.activity={0} cancelled the request to be your {1} agent
 
 manageYourTaxAgents.currentRequests.action.link=Respond to request<span class="govuk-visually-hidden"> from {0} to manage your {1} as a {2} agent</span>
+
+# ________________________________________________________________________________
+# Client confirmation of Deauthorisation page
+# ________________________________________________________________________________
+
+clientConfirmDeauth.h1=Confirm that you want to remove the agent’s authorisation
+clientConfirmDeauth.p1=If you remove your authorisation from {0}, they will no longer be able to manage your {1}.
+clientConfirmDeauth.legend=Do you want to remove your authorisation from {0}?
+clientConfirmDeauth.true=Yes
+clientConfirmDeauth.false=No
+clientConfirmDeauth.error.required=Select ‘Yes’ if you want to remove your authorisation
+
+# ________________________________________________________________________________
+# Confirmation Client has Deauthorised Agent
+# ________________________________________________________________________________
+
+clientDeauthConfirmed.h1=Authorisation removed
+clientDeauthConfirmed.h2=What this means
+clientDeauthConfirmed.p1={0} is no longer authorised to manage your {1}.
+clientDeauthConfirmed.p2=You can change your mind later, just ask {0} to send you another request.
+clientDeauthConfirmed.HMRC-MTD-IT.h2=If {0} manages your Self Assessment
+clientDeauthConfirmed.HMRC-MTD-IT.p1=You will need to remove this authorisation separately, if you no longer want {0} to manage your Self Assessment.
+clientDeauthConfirmed.HMRC-MTD-IT.p2=Read the guidance about how to <a href="{0}" class="govuk-link" target="_blank" rel="noopener noreferrer">change or remove a tax agents authorisation (opens in a new tab)</a>.
+clientDeauthConfirmed.link=Manage who can deal with HMRC for you
+clientDeauthConfirmed.signOutLink=Finish and sign out
 
 # ________________________________________________________________________________
 # Unauthorised exit partials

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsControllerISpec.scala
@@ -18,17 +18,23 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
 
 import play.api.http.Status.*
 import play.api.libs.json.Json
-import play.api.test.Helpers.LOCATION
+import play.api.test.Helpers.{LOCATION, await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.Invitation
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{AgentData, AgentsAuthorisationsResponse, AgentsInvitationsResponse, AuthorisationEventsResponse, ManageYourTaxAgentsData, Pending}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
-import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{AgentData, AgentsAuthorisationsResponse, AgentsInvitationsResponse, Authorisation, AuthorisationEventsResponse, AuthorisationsCache, ManageYourTaxAgentsData, Pending}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.{stubGet, stubPost}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.routes as authRoutes
+import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AuthorisationsCacheService
+import uk.gov.hmrc.mongo.cache.DataKey
 
 import java.time.{Instant, LocalDate}
 
-class ManageYourTaxAgentsControllerISpec extends ComponentSpecHelper with AuthStubs:
+class ManageYourTaxAgentsControllerISpec extends ComponentSpecHelper with AuthStubs with AgentClientRelationshipStub:
 
+  val authorisedAgentsCacheService: AuthorisationsCacheService = app.injector.instanceOf[AuthorisationsCacheService]
+  val authArn: String = "TARN0000001"
+  val testAuthorisationCacheId: String = "auth001"
+  val invalidAuthorisationCacheId: String = "notFound"
   val mytaData: ManageYourTaxAgentsData = ManageYourTaxAgentsData(
     agentsInvitations = AgentsInvitationsResponse(agentsInvitations = Seq(
       AgentData(
@@ -71,6 +77,15 @@ class ManageYourTaxAgentsControllerISpec extends ComponentSpecHelper with AuthSt
     agentsAuthorisations = AgentsAuthorisationsResponse(agentsAuthorisations = Seq.empty),
     authorisationEvents = AuthorisationEventsResponse(authorisationEvents = Seq.empty)
   )
+  val testAuthorisation: Authorisation = Authorisation(
+    uid = testAuthorisationCacheId,
+    service = "HMRC-MTD-IT",
+    clientId = "ABCDEF123456789",
+    date = LocalDate.now().minusDays(10),
+    arn = authArn,
+    agentName = "ABC Accountants",
+    deauthorised = None
+  )
 
   "The show action" should:
 
@@ -89,3 +104,95 @@ class ManageYourTaxAgentsControllerISpec extends ComponentSpecHelper with AuthSt
         val result = get(routes.ManageYourTaxAgentsController.show.url)
         result.status shouldBe SEE_OTHER
         result.header(LOCATION) shouldBe Some(authRoutes.AuthorisationController.cannotViewRequest.url)
+
+  "The show confirm deauth action" should:
+
+    "return status 200" when:
+
+      "authorisation id is valid" in:
+        authoriseAsClient()
+        await(authorisedAgentsCacheService.put[AuthorisationsCache](
+          DataKey("authorisationsCache"),
+          AuthorisationsCache(authorisations = Seq(testAuthorisation))))
+        val result = get(routes.ManageYourTaxAgentsController.showConfirmDeauth(testAuthorisationCacheId).url)
+        result.status shouldBe OK
+
+    "redirect to manage your tax agents page" when:
+
+      "authorisation id is valid but has already been deauthorised" in:
+        authoriseAsClient()
+        await(authorisedAgentsCacheService.put[AuthorisationsCache](
+          DataKey("authorisationsCache"),
+          AuthorisationsCache(authorisations = Seq(
+            testAuthorisation.copy(
+              deauthorised = Some(true)
+            )
+          ))))
+        val result = get(routes.ManageYourTaxAgentsController.showConfirmDeauth(testAuthorisationCacheId).url)
+        result.status shouldBe SEE_OTHER
+        result.header(LOCATION) shouldBe Some(routes.ManageYourTaxAgentsController.show.url)
+
+    "return status 404" when:
+
+      "authorisation id is invalid" in:
+        authoriseAsClient()
+        val result = get(routes.ManageYourTaxAgentsController.showConfirmDeauth(invalidAuthorisationCacheId).url)
+        result.status shouldBe NOT_FOUND
+
+  "The submit confirm deauth action" should:
+
+    "return status 400 BAD_REQUEST" when:
+
+      "form is empty" in:
+        authoriseAsClient()
+        await(authorisedAgentsCacheService.put[AuthorisationsCache](
+          DataKey("authorisationsCache"),
+          AuthorisationsCache(authorisations = Seq(testAuthorisation))))
+        val result = post(routes.ManageYourTaxAgentsController.submitDeauth(testAuthorisationCacheId).url)(Map.empty)
+        result.status shouldBe BAD_REQUEST
+
+    "redirect to manage your tax agents page" when:
+
+      "authorisation id is valid but has already been deauthorised" in:
+        authoriseAsClient()
+        await(authorisedAgentsCacheService.put[AuthorisationsCache](
+          DataKey("authorisationsCache"),
+          AuthorisationsCache(authorisations = Seq(
+            testAuthorisation.copy(
+              deauthorised = Some(true)
+            )
+          ))))
+        val result = post(routes.ManageYourTaxAgentsController.submitDeauth(testAuthorisationCacheId).url)(Map("clientConfirmDeauth" -> Seq("true")))
+        result.status shouldBe SEE_OTHER
+        result.header(LOCATION) shouldBe Some(routes.ManageYourTaxAgentsController.show.url)
+
+      "authorisation id is invalid" in:
+        authoriseAsClient()
+        val result = post(routes.ManageYourTaxAgentsController.submitDeauth(invalidAuthorisationCacheId).url)(Map("clientConfirmDeauth" -> Seq("true")))
+        result.status shouldBe SEE_OTHER
+        result.header(LOCATION) shouldBe Some(routes.ManageYourTaxAgentsController.show.url)
+
+      "authorisation id is valid and user selects No" in:
+        authoriseAsClient()
+        await(authorisedAgentsCacheService.put[AuthorisationsCache](
+          DataKey("authorisationsCache"),
+          AuthorisationsCache(authorisations = Seq(testAuthorisation))))
+        val result = post(routes.ManageYourTaxAgentsController.submitDeauth(testAuthorisationCacheId).url)(Map("clientConfirmDeauth" -> Seq("false")))
+        result.status shouldBe SEE_OTHER
+        result.header(LOCATION) shouldBe Some(routes.ManageYourTaxAgentsController.show.url)
+
+    "redirect to deauth complete page" when:
+
+      "authorisation id is valid and user confirms deauth" in:
+        authoriseAsClient()
+        await(authorisedAgentsCacheService.put[AuthorisationsCache](
+          DataKey("authorisationsCache"),
+          AuthorisationsCache(authorisations = Seq(testAuthorisation))))
+        stubPost(
+          s"/agent-client-relationships/agent/$authArn/remove-authorisation",
+          NO_CONTENT,
+          Json.obj("clientId" -> testAuthorisation.clientId, "service" -> testAuthorisation.service).toString
+        )
+        val result = post(routes.ManageYourTaxAgentsController.submitDeauth(testAuthorisationCacheId).url)(Map("clientConfirmDeauth" -> Seq("true")))
+        result.status shouldBe SEE_OTHER
+        result.header(LOCATION) shouldBe Some(routes.ManageYourTaxAgentsController.deauthComplete(testAuthorisationCacheId).url)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.10.0"
+  private val bootstrapVersion = "9.11.0"
   private val hmrcMongoVersion = "2.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "10.3.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "10.13.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % hmrcMongoVersion,
     "uk.gov.hmrc" %% "play-conditional-form-mapping-play-30" % "3.2.0",
     "uk.gov.hmrc"       %% "crypto-json-play-30"       % "8.2.0"

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationOfDeauthPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationOfDeauthPageSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.views.client
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.Authorisation
+import uk.gov.hmrc.agentclientrelationshipsfrontend.support.ViewSpecSupport
+import uk.gov.hmrc.agentclientrelationshipsfrontend.views.html.client.ConfirmationOfDeauthPage
+
+import java.time.LocalDate
+import scala.language.postfixOps
+
+class ConfirmationOfDeauthPageSpec extends ViewSpecSupport {
+
+  val viewTemplate: ConfirmationOfDeauthPage = app.injector.instanceOf[ConfirmationOfDeauthPage]
+  val testClientName: String = "Test Client"
+  val arn: String = "TARN0000001"
+  val mtditid: String = "ABCDEF123456789"
+  val authDate: LocalDate = LocalDate.now().minusDays(10)
+  val agentName: String = "ABC Accountants"
+  val serviceLabels: Map[String, String] = Map(
+    "HMRC-MTD-IT" -> "Making Tax Digital for Income Tax",
+    "PERSONAL-INCOME-RECORD" -> "Income Record Viewer",
+    "HMRC-MTD-VAT" -> "VAT",
+    "HMRC-CGT-PD" -> "Capital Gains Tax on UK property account",
+    "HMRC-PPT-ORG" -> "Plastic Packaging Tax",
+    "HMRC-CBC-ORG" -> "Country-by-country reports",
+    "HMRC-PILLAR2-ORG" -> "Pillar 2 Top-up Taxes",
+    "HMRC-TERS-ORG" -> "Trusts and Estates",
+    "HMRC-TERSNT-ORG" -> "Trusts and Estates"
+  )
+
+  val confirmationData: Authorisation = Authorisation(
+    uid = "1",
+    agentName = agentName,
+    service = "HMRC-MTD-IT",
+    clientId = mtditid,
+    date = authDate,
+    arn = arn,
+    deauthorised = Some(true)
+  )
+
+  "Confirmation page view for removing authorisation for non-ITSA services from an agent" should {
+      for (taxService <- serviceLabels.keySet.toList.filterNot(_ == "HMRC-MTD-IT")) {
+        val view: HtmlFormat.Appendable = viewTemplate(confirmationData.copy(service = taxService))
+        val doc: Document = Jsoup.parse(view.body)
+        s"include the correct h1 text for $taxService" in {
+          doc.mainContent.extractText("h1.govuk-panel__title", 1).value shouldBe "Authorisation removed"
+        }
+        s"include the correct p1 text for $taxService" in {
+          val expectedContent = s"$agentName is no longer authorised to manage your ${serviceLabels(taxService)}."
+          doc.mainContent.extractText(p, 1).value shouldBe expectedContent
+        }
+      }
+  }
+
+  "Confirmation page view removing authorisation for ITSA from an agent" should {
+    val view: HtmlFormat.Appendable = viewTemplate(confirmationData)
+    val doc: Document = Jsoup.parse(view.body)
+    s"include the correct h1 text for ITSA" in {
+      doc.mainContent.extractText("h1.govuk-panel__title", 1).value shouldBe "Authorisation removed"
+    }
+    s"include the correct text for the first subheading" in {
+      val expectedH2 = "What this means"
+      doc.mainContent.extractText(h2, 1).value shouldBe expectedH2
+    }
+    s"include the correct p1 text for ITSA" in {
+      val expectedContent = s"$agentName is no longer authorised to manage your ${serviceLabels("HMRC-MTD-IT")}."
+      doc.mainContent.extractText(p, 1).value shouldBe expectedContent
+    }
+    s"include extra content for ITSA" in {
+      val expectedH2 = s"If $agentName manages your Self Assessment"
+      doc.mainContent.extractText(h2, 2).value shouldBe expectedH2
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPageSpec.scala
@@ -179,7 +179,7 @@ class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
       AuthorisationEvent(
         agentName = authorisedAgentName,
         service = "HMRC-MTD-IT",
-        date = startDate,
+        date = startDate.minusDays(5),
         eventType = Accepted
       )
     ))
@@ -242,16 +242,16 @@ class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
         caption = authorisedAgentName,
         rows = List(
           IndexedSeq(
-            "Making Tax Digital for Income Tax",
-            "Main",
-            startDate.format(dateFormatter),
-            s"Remove authorisation from $authorisedAgentName to manage your Making Tax Digital for Income Tax as a Main agent"
-          ),
-          IndexedSeq(
             "Pillar 2 Top-up Taxes",
             "Main",
             startDate.format(dateFormatter),
             s"Remove authorisation from $authorisedAgentName to manage your Pillar 2 Top-up Taxes as a Main agent"
+          ),
+          IndexedSeq(
+            "Making Tax Digital for Income Tax",
+            "Main",
+            startDate.format(dateFormatter),
+            s"Remove authorisation from $authorisedAgentName to manage your Making Tax Digital for Income Tax as a Main agent"
           )
         ))
       doc.mainContent.extractTable(4, 4).value shouldBe TestTable(
@@ -291,7 +291,7 @@ class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
             "You declined Bottom Line as your Main agent"
           ),
           IndexedSeq(
-            startDate.format(dateFormatter),
+            startDate.minusDays(5).format(dateFormatter),
             "Making Tax Digital for Income Tax",
             s"You accepted $authorisedAgentName as your Main agent"
           )


### PR DESCRIPTION
In addition to the client led deauth the following fixes were also included:

- forcing message keys to lowercase for InvitationStatus values on TrackRequestsPage to avoid inconsistencies and match the model 
- introduced the agreed sorting for MYTA tab data and updated tests to match - this included sorting the tax service labels alphabetically, the gropued agent names alphabetically and within each agent's table using dates to show next expiry date first on requests, and in the authorisations tables and history tab the dates are newest first in a log fashion