### PR TITLE
APB-9052 feature flags integrated with config

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
@@ -49,6 +49,7 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration)
   // Feature Flags
   val welshLanguageSupportEnabled: Boolean = config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
   val emaEnabled: Boolean = config.get[Boolean]("features.enable-ema")
+  val cbcEnabled: Boolean = config.get[Boolean]("features.enable-cbc")
 
   // Service config
   val appName: String = getString("appName")

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsController.scala
@@ -54,7 +54,7 @@ class ManageYourTaxAgentsController @Inject()(
           .put[AuthorisationsCache](DataKey("authorisationsCache"), AuthorisationsCache(
             authorisations = Seq(mytaData.agentsAuthorisations.agentsAuthorisations).flatten.flatMap(_.authorisations))
           )
-      } yield Ok(mytaPage(serviceConfigurationService.allSupportedServices.map(s => (s, serviceConfigurationService.getUrlPart(s))).toMap, mytaData))
+      } yield Ok(mytaPage(serviceConfigurationService.allEnabledServices.map(s => (s, serviceConfigurationService.getUrlPart(s))).toMap, mytaData))
 
   def showConfirmDeauth(id: String): Action[AnyContent] = actions.clientAuthenticate.async:
     implicit request =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -75,16 +75,7 @@ features.welsh-language-support = true
 play.i18n.langs = ["en", "cy"]
 
 features {
-  show-hmrc-mtd-it = true
-  show-personal-income = true
-  show-hmrc-mtd-vat = true
-  show-hmrc-trust = true
-  show-hmrc-cgt = true
-  show-plastic-packaging-tax = true
-  show-cbc = true
-  show-pillar2 = true
-  enable-alt-itsa = true
-  enable-welsh-toggle = true
+  enable-cbc = true
   enable-ema = true
 }
 


### PR DESCRIPTION
We only have 2 tax regime based feature flags (EMA and CBC) - so the others were removed from application.conf as they are not used for anything at all and might even make a bit of a mess if they were to be turned off and respected in the FE but not in other services where a substantial legacy of authorisations and invitations will exist.