### PR TITLE
APB-9130 Updating signout to route correctly, adding serviceIds and survey redirects

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/config/AppConfig.scala
@@ -34,7 +34,12 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration)
   val ivUpliftUrl: String = getConfString("identity-verification-frontend.uplift-url")
   val signInUrl: String = getString("sign-in.url")
   val subscriptionUrl: String = getConfString("agent-subscription-frontend.subscription-url")
-  val clientLinkBaseUrl: String = s"${appExternalUrl}/agent-client-relationships/appoint-someone-to-deal-with-HMRC-for-you"
+  val clientLinkBaseUrl: String = s"$appExternalUrl/agent-client-relationships/appoint-someone-to-deal-with-HMRC-for-you"
+  val feedbackSurveyUrl: String = getConfString("feedback-frontend.external-url")
+  def surveyUrl(isAgent: Boolean): String = {
+    if isAgent then s"$feedbackSurveyUrl/$agentOriginToken"
+    else s"$feedbackSurveyUrl/$clientOriginToken"
+  }
 
   // GovUk Urls
   val govUkUrl: String = getString("gov-uk.url")
@@ -56,6 +61,8 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration)
   val allowedRedirectHosts: Set[String] = config.getOptional[Seq[String]]("allowed-redirect-hosts").getOrElse(Nil).toSet
   val trackRequestsPageSize: Int = servicesConfig.getInt("track-requests-per-page")
   val authorisationRequestExpiryDays: Int = servicesConfig.getDuration("invitation.expiryDuration").toDays.toInt
+  val agentOriginToken = "INVITAGENT"
+  val clientOriginToken = "INVITCLIENT"
 
   val countryListLocation: String = servicesConfig.getString("country.list.location")
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationController.scala
@@ -68,7 +68,7 @@ class AuthorisationController @Inject()(mcc: MessagesControllerComponents,
 
   def ivTimedOut(continueUrl: Option[RedirectUrl]): Action[AnyContent] = Action.async:
     implicit request =>
-      Future.successful(Forbidden(timedOutView(continueUrl.map(UrlHelper.validateRedirectUrl))))
+      Future.successful(Forbidden(timedOutView(continueUrl.map(UrlHelper.validateRedirectUrl), isAgent = false)))
 
   def ivLockedOut: Action[AnyContent] = Action.async:
     implicit request =>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/SignOutController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.routes as clientRoutes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.UrlHelper.validateRedirectUrl
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -29,11 +30,9 @@ import scala.concurrent.Future
 class SignOutController @Inject()(mcc: MessagesControllerComponents)
                                  (implicit appConfig: AppConfig) extends FrontendController(mcc):
 
-  def signOut(continueUrl: Option[RedirectUrl] = None): Action[AnyContent] = Action.async: _ =>
+  def signOut(continueUrl: Option[RedirectUrl] = None, isAgent: Boolean): Action[AnyContent] = Action.async: _ =>
     continueUrl match {
       case Some(url) => Future.successful(Redirect(validateRedirectUrl(url)).withNewSession)
-      // previously the generic behaviour and destination of sign out was determined by MainTemplate code
-      // instead we could do that in here (when no continue url is provided manually)
-      case None => Future.successful(Ok("Signed out").withNewSession)
+      case None if isAgent => Future.successful(Redirect(appConfig.agentServicesAccountHomeUrl).withNewSession)
+      case None => Future.successful(Redirect(clientRoutes.ManageYourTaxAgentsController.show).withNewSession)
     }
-

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/TimedOutController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/TimedOutController.scala
@@ -32,7 +32,7 @@ class TimedOutController @Inject()(
                                     mcc: MessagesControllerComponents
                                   )(implicit appConfig: AppConfig) extends FrontendController(mcc):
 
-  def timedOut(continueUrl: RedirectUrl, serviceHeader: String): Action[AnyContent] = Action.async:
+  def timedOut(continueUrl: RedirectUrl, serviceHeader: String, isAgent: Boolean): Action[AnyContent] = Action.async:
     request =>
       given MessagesRequest[AnyContent] = request
-      Future.successful(Ok(timedOutView(Some(validateRedirectUrl(continueUrl)), Some(serviceHeader))))
+      Future.successful(Ok(timedOutView(Some(validateRedirectUrl(continueUrl)), Some(serviceHeader), isAgent)))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/EncryptedSessionCacheRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/EncryptedSessionCacheRepository.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.repositories
 
-import play.api.libs.json.{Format, Reads, Writes}
+import play.api.libs.json.{Reads, Writes}
 import play.api.mvc.RequestHeader
-import uk.gov.hmrc.crypto.json.JsonEncryption.{sensitiveDecrypter, sensitiveEncrypter, sensitiveEncrypterDecrypter}
+import uk.gov.hmrc.crypto.json.JsonEncryption.{sensitiveDecrypter, sensitiveEncrypter}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, Sensitive}
 import uk.gov.hmrc.mongo.cache.{DataKey, SessionCacheRepository}
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/AgentCancelInvitationCompletePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/AgentCancelInvitationCompletePage.scala.html
@@ -37,7 +37,8 @@
 
 @layout(
     pageTitle = pageTitle,
-    suppressBackLink = true
+    suppressBackLink = true,
+    isAgent = true
 ) {
     @govukPanel(Panel(
         title = Text(pageTitle)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/AgentCancelInvitationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/AgentCancelInvitationPage.scala.html
@@ -41,7 +41,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages("authorisation-request.service.name"))
+    serviceName = Some(messages("authorisation-request.service.name")),
+    isAgent = true
 ) {
     @formWithCSRF(action = routes.AgentCancelInvitationController.submit(authorisationRequestInfo.invitationId)) {
         @govukRadios(Radios(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/ErrorTemplate.scala.html
@@ -20,7 +20,10 @@
 
 @(pageTitle: String, heading: String, message: String)(implicit request: RequestHeader, messages: Messages)
 
-@layout(pageTitle) {
+@layout(
+ pageTitle,
+ isAgent = true //User is not necessarily agent, we could add an auth check to rule out this being a client in the error handler
+) {
     <h1 class="govuk-heading-xl">@{Text(heading).asHtml}</h1>
     <p class="govuk-body">@{Text(message).asHtml}</p>
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/Layout.scala.html
@@ -25,6 +25,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage._
 @import views.html.helper.CSPNonce
 @import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
+@import uk.gov.hmrc.hmrcfrontend.config.ContactFrontendConfig
 
 @this(
         appConfig: AppConfig,
@@ -33,9 +34,10 @@
         autocompleteCss: HmrcAccessibleAutocompleteCss,
         autocompleteJavascript: HmrcAccessibleAutocompleteJavascript,
         hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper,
-        hmrcReportTechnicalIssueHelper: HmrcReportTechnicalIssueHelper,
+        hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
         fullWidthLayout: FullWidthLayout,
-        twoThirdsMainContent: TwoThirdsMainContent
+        twoThirdsMainContent: TwoThirdsMainContent,
+        contactFrontendConfig: ContactFrontendConfig
 )
 
 @(
@@ -44,12 +46,15 @@
         optionalForm: Option[Form[?]] = None,
         backLinkHref: Option[String] = None,
         suppressBackLink: Boolean = false,
-        fullWidth: Boolean = false
+        fullWidth: Boolean = false,
+        isAgent: Boolean,
+        showSurvey: Boolean = false
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @isSignedIn  = @{request.session.get("authToken").isDefined}
-@* sign out url is only available if the user is signed in, the signOut method can do survey redirection etc *@
-@signOutUrl = @{if(isSignedIn) Some(routes.SignOutController.signOut().url) else None}
+@* ported over logic from AIF, agents are shown feedback form at journey end, clients are shown at any point, may need reviewing *@
+@optSurveyUrl = @{if(showSurvey || !isAgent) Some(RedirectUrl(appConfig.surveyUrl(isAgent))) else None}
+@signOutUrl = @{if(isSignedIn) Some(routes.SignOutController.signOut(continueUrl = optSurveyUrl, isAgent = isAgent).url) else None}
 @* only pass in the service name as a fully resolved message if it is not the default for agents auth *@
 @service = @{serviceName.getOrElse(messages("service.name.agents.auth"))}
 @head = {
@@ -58,7 +63,8 @@
             signOutUrl = signOutUrl.get,
             timeoutUrl = Some(routes.TimedOutController.timedOut(
                 continueUrl = RedirectUrl(s"${appConfig.appExternalUrl}${request.uri}"),
-                serviceHeader = service
+                serviceHeader = service,
+                isAgent = isAgent
             ).url)
         )
     }
@@ -92,7 +98,12 @@ equal the page heading (H1) content, if they are identical then only the service
     }
     @contentBlock
     <div class="govuk-!-display-none-print govuk-!-margin-top-6">
-        @hmrcReportTechnicalIssueHelper()
+        @hmrcReportTechnicalIssue(ReportTechnicalIssue(
+            serviceId = if(isAgent) appConfig.agentOriginToken else appConfig.clientOriginToken,
+            language = if(messages.lang.code == "cy") Cy else En,
+            referrerUrl = contactFrontendConfig.referrerUrl,
+            baseUrl = contactFrontendConfig.baseUrl
+        ))
     </div>
 }
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/PageNotFound.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/PageNotFound.scala.html
@@ -27,7 +27,10 @@
     messages(s"$key.header")
 }
 
-@layout(pageTitle) {
+@layout(
+    pageTitle,
+    isAgent = true
+) {
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     <p class="govuk-body">@messages(s"$key.text")</p>
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/ResendInvitationLink.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/ResendInvitationLink.scala.html
@@ -39,7 +39,9 @@
 
 @layout(
     pageTitle = pageTitle,
-    serviceName = Some(messages("authorisation-request.service.name"))
+    serviceName = Some(messages("authorisation-request.service.name")),
+    isAgent = true,
+    showSurvey = true
 ) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TrackRequestsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/TrackRequestsPage.scala.html
@@ -132,7 +132,11 @@
     }
 }
 
-@layout(pageTitle, fullWidth = true) {
+@layout(
+    pageTitle,
+    fullWidth = true,
+    isAgent = true
+) {
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     @filterContent
     @if(result.requests.nonEmpty) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOut.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOut.scala.html
@@ -23,7 +23,7 @@
         govukButton: GovukButton
 )
 
-@(continueUrl: Option[String], serviceHeader: Option[String] = None)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
+@(continueUrl: Option[String], serviceHeader: Option[String] = None, isAgent: Boolean)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
 
 @timeString = @{
     val timeout = appConfig.timeoutDialogTimeoutSeconds
@@ -35,7 +35,8 @@
 
 @layout(
     pageTitle = title,
-    serviceName = Some(serviceName)
+    serviceName = Some(serviceName),
+    isAgent = isAgent
 ) {
 
     @h1(title)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentity.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/CannotConfirmIdentity.scala.html
@@ -29,7 +29,8 @@
 
 @layout(
     pageTitle = messages("cannot-confirm-identity.header"),
-    serviceName = Some(messages("service.name.clients"))
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
 ) {
     @h1(messages("cannot-confirm-identity.header"))
     <p class="govuk-body"> @messages("cannot-confirm-identity.p1") </p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequest.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequest.scala.html
@@ -28,7 +28,8 @@
 
 @layout(
     pageTitle = messages("error.cannot-view-request.header"),
-    serviceName = Some(messages("service.name.clients"))
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
 ) {
 
     @h1(messages("error.cannot-view-request.header"))
@@ -39,7 +40,7 @@
 
     @govukButton(Button(
         content = Text(messages("error.cannot-view-request.button")),
-        href = Some(routes.SignOutController.signOut(continueUrl).url) //Not the right link but is being redone shortly with APB-9294 and will be removed before live
+        href = Some(routes.SignOutController.signOut(continueUrl, isAgent = false).url) //Not the right link but is being redone shortly with APB-9294 and will be removed before live
     ))
 
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOut.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvLockedOut.scala.html
@@ -28,7 +28,8 @@
 
 @layout(
     pageTitle = messages("locked-out.header"),
-    serviceName = Some(messages("service.name.clients"))
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
 ) {
     @h1(messages("locked-out.header"))
     <p class="govuk-body"> @messages("locked-out.p1") </p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficulties.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/IvTechDifficulties.scala.html
@@ -27,7 +27,8 @@
 
 @layout(
     pageTitle = messages("technical-issues.header"),
-    serviceName = Some(messages("service.name.clients"))
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
 ) {
     @h1(messages("technical-issues.header"))
     <p class="govuk-body"> @messages("technical-issues.p1") </p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClient.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClient.scala.html
@@ -27,7 +27,8 @@
 
 @layout(
     pageTitle = messages("not-authorised.header"),
-    serviceName = Some(messages("service.name.clients"))
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
 ) {
 
     @h1(messages("not-authorised.header"))
@@ -36,7 +37,7 @@
 
     @govukButton(Button(
         content = Text(messages("not-authorised.button")),
-        href = Some(routes.SignOutController.signOut().url)
+        href = Some(routes.SignOutController.signOut(isAgent = false).url)
     ))
 
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/AuthoriseAgentStartPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/AuthoriseAgentStartPage.scala.html
@@ -32,7 +32,11 @@
     messages(s"$key.h1.$taxService", agentName)
 }
 
-@layout(pageTitle = title, serviceName = Some(messages("service.name.clients"))) {
+@layout(
+    pageTitle = title,
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
+) {
 
     @h1(title)
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/CheckYourAnswerPage.scala.html
@@ -44,7 +44,8 @@
 
 @layout(
     pageTitle,
-    serviceName = Some(messages("service.name.clients"))
+    serviceName = Some(messages("service.name.clients")),
+    isAgent = false
 ) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPage.scala.html
@@ -37,7 +37,11 @@
 @serviceName = @{messages("service.name.clients")}
 @pageTitle = @{messages(s"$key.$exitType.header")}
 
-@layout(pageTitle, Some(serviceName)) {
+@layout(
+    pageTitle,
+    Some(serviceName),
+    isAgent = false
+) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     @{

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmConsentPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmConsentPage.scala.html
@@ -85,7 +85,12 @@
     </ul>
 }
 
-@layout(pageTitle, Some(serviceName), Some(form)) {
+@layout(
+    pageTitle,
+    Some(serviceName),
+    Some(form),
+    isAgent = false
+) {
 
     <h2 class="govuk-caption-xl">@messages(serviceKey)</h2>
     <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmDeauthPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmDeauthPage.scala.html
@@ -35,7 +35,12 @@
 @pageTitle = @{messages(s"$key.h1")}
 @serviceName = @{messages("service.name.clients")}
 
-@layout(pageTitle, Some(serviceName), Some(form)) {
+@layout(
+    pageTitle,
+    Some(serviceName),
+    Some(form),
+    isAgent = false
+) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     <p class="govuk-body">@messages(s"$key.p1", authorisation.agentName, taxServiceName)</p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationOfDeauthPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationOfDeauthPage.scala.html
@@ -35,7 +35,8 @@
 @layout(
     pageTitle = pageTitle,
     serviceName = Some(messages("manageYourTaxAgents.header")),
-    suppressBackLink = true
+    suppressBackLink = true,
+    isAgent = false
 ) {
 
     @govukPanel(Panel(title = Text(pageTitle)))
@@ -55,7 +56,7 @@
     </p>
 
     <p class="govuk-body">
-        <a class="govuk-link" href="@{routes.SignOutController.signOut().url}">@messages(s"$key.signOutLink")</a>
+        <a class="govuk-link" href="@{routes.SignOutController.signOut(isAgent = false).url}">@messages(s"$key.signOutLink")</a>
     </p>
     
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPage.scala.html
@@ -51,7 +51,8 @@
 @layout(
     pageTitle = pageTitle,
     serviceName = Some(messages("service.name.clients")),
-    suppressBackLink = true
+    suppressBackLink = true,
+    isAgent = false
 ) {
 
     @govukPanel(Panel(title = Text(pageTitle)))
@@ -70,7 +71,7 @@
         <li>@messages(s"$key.section2.li3")</li>
     </ul>
     <p class="govuk-body">
-        <a class="govuk-link" href="@{routes.SignOutController.signOut().url}">@messages(s"$key.section2.signOutLink")</a>
+        <a class="govuk-link" href="@{routes.SignOutController.signOut(isAgent = false).url}">@messages(s"$key.section2.signOutLink")</a>
     </p>
     
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPage.scala.html
@@ -37,7 +37,11 @@
 @indefiniteAgentRole = @{if appConfig.emaEnabled then messages(s"indefiniteAgentRole.$serviceKey") else messages("indefiniteAgentRole.noEMA")}
 @taxServiceName = @{messages(serviceKey)}
 
-@layout(pageTitle, Some(serviceName)) {
+@layout(
+    pageTitle,
+    Some(serviceName),
+    isAgent = false
+) {
 
   <h2 class="govuk-caption-xl">@messages(serviceKey)</h2>
   <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/DeclineRequestPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/DeclineRequestPage.scala.html
@@ -33,7 +33,12 @@
 @pageTitle = @{messages(s"$key.title")}
 @serviceName = @{messages("service.name.clients")}
 
-@layout(pageTitle, Some(serviceName), Some(form)) {
+@layout(
+    pageTitle,
+    Some(serviceName),
+    Some(form),
+    isAgent = false
+) {
 
   <h2 class="govuk-caption-xl">@messages(serviceKey)</h2>
   <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
@@ -210,7 +210,12 @@
     else Seq(currentRequestsTab, authorisedAgentsTab, historyTab)
 }
 
-@layout(pageTitle, Some(pageTitle), fullWidth = true) {
+@layout(
+    pageTitle,
+    Some(pageTitle),
+    fullWidth = true,
+    isAgent = false
+) {
     @h1(pageTitle)
     @govukDetails(Details(summary = Text(messages(s"$key.p")), content = HtmlContent(servicesList)))
     @if(appConfig.emaEnabled) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AgentSuspended.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AgentSuspended.scala.html
@@ -26,4 +26,4 @@
 <p class="govuk-body">@messages(s"$key.p2")</p>
 
 <a id="guidanceLink" class="govuk-link"
-href='@Some(routes.SignOutController.signOut().url)'>@messages(s"$key.signout-link")</a>
+href='@Some(routes.SignOutController.signOut(isAgent = false).url)'>@messages(s"$key.signout-link")</a>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/CannotFindAuthRequest.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/CannotFindAuthRequest.scala.html
@@ -26,4 +26,4 @@
 
 <p class="govuk-body">@messages(s"$key.p1", agentName.getOrElse(""))</p>
 <p class="govuk-body">@Html(messages(s"$key.p2", s"${appConfig.guidanceAuthoriseAgent}"))</p>
-<p class="govuk-body">@Html(messages(s"$key.p3", routes.SignOutController.signOut().url)) </p>
+<p class="govuk-body">@Html(messages(s"$key.p3", routes.SignOutController.signOut(isAgent = false).url)) </p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentCancelAuthorisationCompletePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/AgentCancelAuthorisationCompletePage.scala.html
@@ -38,7 +38,8 @@
 @layout(
     pageTitle = pageTitle,
     serviceName = Some(messages("agent-cancel-authorisation.service.name")),
-    suppressBackLink = true
+    suppressBackLink = true,
+    isAgent = true
 ) {
 
     @govukPanel(Panel(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CheckYourAnswersPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CheckYourAnswersPage.scala.html
@@ -83,7 +83,8 @@
 
 @layout(
     pageTitle = pageTitle,
-    serviceName = Some(messages(s"${request.journey.journeyType.toString}.service.name"))
+    serviceName = Some(messages(s"${request.journey.journeyType.toString}.service.name")),
+    isAgent = true
 ) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmCancellationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmCancellationPage.scala.html
@@ -52,7 +52,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"${request.journey.journeyType.toString}.service.name"))
+    serviceName = Some(messages(s"${request.journey.journeyType.toString}.service.name")),
+    isAgent = true
 ) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ConfirmClientPage.scala.html
@@ -45,7 +45,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @formWithCSRF(action = routes.ConfirmClientController.onSubmit(request.journey.journeyType)) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/CreateAuthorisationRequestCompletePage.scala.html
@@ -41,7 +41,9 @@
 @layout(
     pageTitle = pageTitle,
     serviceName = Some(messages("authorisation-request.service.name")),
-    suppressBackLink = true
+    suppressBackLink = true,
+    isAgent = true,
+    showSurvey = true
 ) {
 
     @govukPanel(Panel(

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientFactPage.scala.html
@@ -48,7 +48,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @{

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientIdPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/EnterClientIdPage.scala.html
@@ -45,7 +45,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @formWithCSRF(action = routes.EnterClientIdController.onSubmit(request.journey.journeyType)) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/JourneyExitPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/JourneyExitPage.scala.html
@@ -39,7 +39,11 @@
 @key = @{"journeyExit"}
 @pageTitle = @{messages(s"$key.$exitType.header")}
 
-@layout(pageTitle, serviceName = Some(messages(s"${journeyType.toString}.service.name"))) {
+@layout(
+    pageTitle,
+    serviceName = Some(messages(s"${journeyType.toString}.service.name")),
+    isAgent = true
+) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     @{

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/PageNotFound.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/PageNotFound.scala.html
@@ -27,7 +27,10 @@
     messages(s"$key.header")
 }
 
-@layout(pageTitle) {
+@layout(
+    pageTitle,
+    isAgent = true
+) {
     <h1 class="govuk-heading-xl">@pageTitle</h1>
 
     <p class="govuk-body">@messages(s"$key.p1")</p>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectAgentRolePage.scala.html
@@ -44,7 +44,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @h1(pageTitle)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientServicePage.scala.html
@@ -52,7 +52,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @formWithCSRF(action = routes.SelectServiceController.onSubmit(request.journey.journeyType)) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientTypePage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/SelectClientTypePage.scala.html
@@ -40,7 +40,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @formWithCSRF(action = routes.SelectClientTypeController.onSubmit(request.journey.journeyType)) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/journey/ServiceRefinementPage.scala.html
@@ -39,7 +39,8 @@
 @layout(
     pageTitle = pageTitle,
     optionalForm = Some(form),
-    serviceName = Some(messages(s"$journeyKey.service.name"))
+    serviceName = Some(messages(s"$journeyKey.service.name")),
+    isAgent = true
 ) {
 
     @formWithCSRF(action = routes.ServiceRefinementController.onSubmit(request.journey.journeyType)) {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/testOnly/TestOnlyAsaDashboard.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/testOnly/TestOnlyAsaDashboard.scala.html
@@ -25,7 +25,8 @@
 
 @layout(
     pageTitle,
-    serviceName = Some("Agent Services Account")
+    serviceName = Some("Agent Services Account"),
+    isAgent = true
 ) {
 
     <h1 class="govuk-heading-xl">@pageTitle</h1>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/testOnly/TestOnlyFastTrack.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/testOnly/TestOnlyFastTrack.scala.html
@@ -42,7 +42,12 @@
     )
 }
 
-@layout(pageTitle = "Test Only: Fast Track Invitation", optionalForm = None, backLinkHref = None) {
+@layout(
+    pageTitle = "Test Only: Fast Track Invitation",
+    optionalForm = None,
+    backLinkHref = None,
+    isAgent = true
+) {
     <h1>Test Only: Fast Track Invitation</h1>
 
     @formWithCSRF(action = Call("POST", postToInvitations)) {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -16,8 +16,8 @@ POST        /manage-authorisation-requests/confirm-cancellation/:invitationId   
 GET         /manage-authorisation-requests/cancellation-confirmation/:invitationId      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AgentCancelInvitationController.complete(invitationId: String)
 
 # Sign out/Timed out ---------------------------------------------------------------------------------------------------------
-GET         /timed-out                                                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TimedOutController.timedOut(continueUrl: RedirectUrl, serviceHeader: String)
-GET         /sign-out                                                                   uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.SignOutController.signOut(continueUrl: Option[RedirectUrl] ?= None)
+GET         /timed-out                                                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.TimedOutController.timedOut(continueUrl: RedirectUrl, serviceHeader: String, isAgent: Boolean)
+GET         /sign-out                                                                   uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.SignOutController.signOut(continueUrl: Option[RedirectUrl] ?= None, isAgent: Boolean)
 
 # Auth/IV --------------------------------------------------------------------------------------------------------------------
 GET         /cannot-view-request                                                        uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.AuthorisationController.cannotViewRequest(continueUrl: Option[RedirectUrl] ?= None, taxService: Option[String] ?= None)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -41,6 +41,9 @@ microservice {
             host = localhost
             port = 9250
         }
+        feedback-frontend {
+            external-url = "http://localhost:9514/feedback"
+        }
         agent-client-relationships-frontend {
             external-url = "http://localhost:9435"
         }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/SignOutControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/SignOutControllerISpec.scala
@@ -16,24 +16,32 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers
 
-import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.http.Status.SEE_OTHER
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.routes as clientRoutes
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 
 class SignOutControllerISpec extends ComponentSpecHelper with AuthStubs {
 
   "GET /sign-out" should {
-    "redirect to continueUrl when it is provided" in {
+    "sign out and redirect to continueUrl when it is provided" in {
       authoriseAsAgent()
       val continueUrl = RedirectUrl("/url/continue")
-      val result = get(routes.SignOutController.signOut(Some(continueUrl)).url)
+      val result = get(routes.SignOutController.signOut(Some(continueUrl), true).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "/url/continue"
     }
-    "return OK" in {
+    "sign out and redirect to ASA if user is an agent" in {
       authoriseAsAgent()
-      val result = get(routes.SignOutController.signOut().url)
-      result.status shouldBe OK
+      val result = get(routes.SignOutController.signOut(isAgent = true).url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe "http://localhost:9401/agent-services-account/home"
+    }
+    "sign out redirect to MYTA if user is a client" in {
+      authoriseAsAgent()
+      val result = get(routes.SignOutController.signOut(isAgent = false).url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe clientRoutes.ManageYourTaxAgentsController.show.url
     }
   }
 

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/TimedOutControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/TimedOutControllerISpec.scala
@@ -24,7 +24,7 @@ class TimedOutControllerISpec extends ComponentSpecHelper with AuthStubs {
 
   "GET /timed-out" should {
     "return OK" in {
-      val result = get(routes.TimedOutController.timedOut(RedirectUrl("/agent-client-relationships"), "Agents").url)
+      val result = get(routes.TimedOutController.timedOut(RedirectUrl("/agent-client-relationships"), "Agents", isAgent = true).url)
       result.status shouldBe OK
     }
   }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOutSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/UserTimedOutSpec.scala
@@ -46,7 +46,7 @@ class UserTimedOutSpec extends ViewSpecSupport {
 
   "UserTimedOut view" when {
     "viewed as a client" should {
-      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl))
+      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), isAgent = true)
       val doc: Document = Jsoup.parse(view.body)
       "have the right title" in {
         doc.title() shouldBe ExpectedClient.title
@@ -65,7 +65,7 @@ class UserTimedOutSpec extends ViewSpecSupport {
       }
     }
     "viewed as an agent on an authorisation request journey" should {
-      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), Some("Ask a client to authorise you"))
+      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), Some("Ask a client to authorise you"), isAgent = true)
       val doc: Document = Jsoup.parse(view.body)
       "have the right title" in {
         doc.title() shouldBe ExpectedAgent.authorisationRequestTitle
@@ -85,7 +85,7 @@ class UserTimedOutSpec extends ViewSpecSupport {
       }
     }
     "viewed as an agent on a cancel authorisation journey" should {
-      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), Some("Cancel a client’s authorisation"))
+      val view: HtmlFormat.Appendable = viewTemplate(Some(testUrl), Some("Cancel a client’s authorisation"), isAgent = true)
       val doc: Document = Jsoup.parse(view.body)
       "have the right title" in {
         doc.title() shouldBe ExpectedAgent.cancelAuthorisationTitle

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequestSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/ErrorCannotViewRequestSpec.scala
@@ -69,7 +69,7 @@ class ErrorCannotViewRequestSpec extends ViewSpecSupport with BeforeAndAfterEach
         doc.mainContent.extractText(p, 3).value shouldBe Expected.para3
       }
       "have a link button" in {
-        doc.mainContent.extractLinkButton(1).value shouldBe TestLink(Expected.button, routes.SignOutController.signOut(Some(RedirectUrl(testUrl))).url)
+        doc.mainContent.extractLinkButton(1).value shouldBe TestLink(Expected.button, routes.SignOutController.signOut(Some(RedirectUrl(testUrl)), isAgent = false).url)
       }
     }
   }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClientSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/auth/NotAuthorisedAsClientSpec.scala
@@ -55,7 +55,7 @@ class NotAuthorisedAsClientSpec extends ViewSpecSupport with BeforeAndAfterEach 
       doc.mainContent.extractText(p, 2).value shouldBe Expected.para2
     }
     "have a link button" in {
-      doc.mainContent.extractLinkButton(1).value shouldBe TestLink(Expected.button, routes.SignOutController.signOut().url)
+      doc.mainContent.extractLinkButton(1).value shouldBe TestLink(Expected.button, routes.SignOutController.signOut(isAgent = false).url)
     }
   }
 }

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
@@ -185,7 +185,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
 
     "have the correct link in the details component content" in {
 
-      doc.mainContent.extractLink(1).value shouldBe TestLink("Finish and sign out", "/agent-client-relationships/sign-out")
+      doc.mainContent.extractLink(1).value shouldBe TestLink("Finish and sign out", "/agent-client-relationships/sign-out?isAgent=false")
     }
   }
 


### PR DESCRIPTION
Added AIF serviceIDs for client and agent pages
Updated help link to use the serviceIDs
Updated signout url to route to asa (for agents) or myta (for clients) after signing them out without a provided continue url
Updated Layout to require a isAgent flag
Updated Layout to support a surveyRequired flag (defaulted to false)
Updated Layout to create a feedback form continue url for the signout redirect (using the two serviceIDs), survey is required at journey end for agents or any client page (ported over logic from AIF)
