### PR TITLE
APB-9135 Improve test coverage

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentCancelInvitationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AgentCancelInvitationController.scala
@@ -54,7 +54,7 @@ class AgentCancelInvitationController @Inject()(
         formWithErrors => {
           acrService.getAuthorisationRequest(invitationId = invitationId).map {
             case Some(info) =>
-              Ok(agentCancelInvitationPage(formWithErrors, info))
+              BadRequest(agentCancelInvitationPage(formWithErrors, info))
             case None =>
               throw new RuntimeException(s"Invitation not found for invitationId: $invitationId")
           }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/TextFormFieldHelper.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/TextFormFieldHelper.scala
@@ -23,8 +23,7 @@ import play.api.data.validation.*
 object TextFormFieldHelper extends FormFieldHelper {
   // all text fields in this service are for ids or codes, so we strip all white spaces
   private def stripWhiteSpaces(str: String): String = str.trim.replaceAll("\\s", "")
-  val emptyMapping: (String, Mapping[String]) = "" -> optional(text).transform(_.getOrElse(""), (Some(_)): String => Option[String])
-  
+
   def textFieldMapping(fieldName: String, formMessageKey: String, regex: String = ".*"): Mapping[String] = {
     optional(text)
       .verifying(validateText(fieldName, formMessageKey, regex))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/modules/CryptoProviderModule.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/modules/CryptoProviderModule.scala
@@ -25,7 +25,7 @@ import java.util.Base64
 
 class CryptoProviderModule extends Module {
 
-  private def aesGcmCryptoInstance(configuration: Configuration): Encrypter & Decrypter =
+  private[modules] def aesGcmCryptoInstance(configuration: Configuration): Encrypter & Decrypter =
     if configuration.underlying.getBoolean("mongoEncryption.enable") then
       SymmetricCryptoFactory.aesGcmCryptoFromConfig("mongoEncryption", configuration.underlying)
     else

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/EncryptedSessionCacheRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/repositories/EncryptedSessionCacheRepository.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.repositories
 
-import play.api.libs.json.{Format, Reads, Writes}
+import play.api.libs.json.{Reads, Writes}
 import play.api.mvc.RequestHeader
-import uk.gov.hmrc.crypto.json.JsonEncryption.{sensitiveDecrypter, sensitiveEncrypter, sensitiveEncrypterDecrypter}
+import uk.gov.hmrc.crypto.json.JsonEncryption.{sensitiveDecrypter, sensitiveEncrypter}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, Sensitive}
 import uk.gov.hmrc.mongo.cache.{DataKey, SessionCacheRepository}
 

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/AuthorisationControllerISpec.scala
@@ -20,7 +20,6 @@ import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.json.Json
 import play.api.libs.ws.{BodyReadable, DefaultBodyReadables}
 import play.api.test.Helpers.*
-import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.ComponentSpecHelper
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
@@ -28,8 +27,6 @@ import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 class AuthorisationControllerISpec extends ComponentSpecHelper {
 
   given BodyReadable[String] = DefaultBodyReadables.readableAsString
-
-  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
   implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(request)
 

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentControllerISpec.scala
@@ -48,9 +48,15 @@ class ConfirmConsentControllerISpec extends ComponentSpecHelper with AuthStubs w
 
     "return status 200 OK" when:
 
-      "a service key and agent name are retrieved from the session" in:
+      "a service key and agent name are retrieved from the session, with a consent answer already defined" in:
         authoriseAsClient()
         await(journeyService.saveJourney(journeyModel))
+        val result = get(routes.ConfirmConsentController.show.url)
+        result.status shouldBe OK
+
+      "a service key and agent name are retrieved from the session, with no consent answer defined" in :
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel.copy(consent = None)))
         val result = get(routes.ConfirmConsentController.show.url)
         result.status shouldBe OK
 
@@ -99,11 +105,12 @@ class ConfirmConsentControllerISpec extends ComponentSpecHelper with AuthStubs w
         result.status shouldBe BAD_REQUEST
 
     "kick the user out to MYTA" when :
+
       "a service key is not present in the session" in:
         authoriseAsClient()
         val badJourneyModel = journeyModel.copy(serviceKey = None)
         await(journeyService.saveJourney(badJourneyModel))
-        val result = get(routes.ConfirmConsentController.show.url)
+        val result = post(routes.ConfirmConsentController.submit.url)(Map("confirmConsent" -> Seq("true")))
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ManageYourTaxAgentsController.show.url
 
@@ -111,6 +118,6 @@ class ConfirmConsentControllerISpec extends ComponentSpecHelper with AuthStubs w
         authoriseAsClient()
         val badJourneyModel = journeyModel.copy(agentName = None)
         await(journeyService.saveJourney(badJourneyModel))
-        val result = get(routes.ConfirmConsentController.show.url)
+        val result = post(routes.ConfirmConsentController.submit.url)(Map("confirmConsent" -> Seq("true")))
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ManageYourTaxAgentsController.show.url

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationControllerISpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientJourneyServic
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubGet
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
-class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
+class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs :
 
   val testInvitationId: String = "AB1234567890"
 
@@ -64,20 +64,25 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs {
     super.beforeEach()
   }
 
-  "GET /authorisation-response/confirmation" should {
-    "redirect to MYTA when no journey session present" in {
+  "GET /authorisation-response/confirmation" should :
+
+    "redirect to MYTA when no journey session present" in :
       authoriseAsClient()
       val result = get(routes.ConfirmationController.show.url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe "/agent-client-relationships/manage-your-tax-agents"
-    }
-    List(Accepted, Rejected, PartialAuth).foreach(decision => s"display the confirmation page for ${decision.toString} when the invitation id is in journeyComplete" in {
+
+    List(Accepted, Rejected, PartialAuth).foreach(decision => s"display the confirmation page for ${decision.toString} when the invitation id is in journeyComplete" in :
       authoriseAsClientWithEnrolments("HMRC-MTD-IT")
       stubGet(getAuthorisationRequestUrl, OK, testGetAuthorisationRequestInfoResponse("HMRC-MTD-IT", decision).toString())
       await(journeyService.saveJourney(completeJourney))
       val result = get(routes.ConfirmationController.show.url)
       result.status shouldBe OK
-    })
-  }
+    )
 
-}
+    "return 500 when ACR does not return an invitation for the invitationId in session" in :
+      authoriseAsClient()
+      stubGet(getAuthorisationRequestUrl, NOT_FOUND, "")
+      await(journeyService.saveJourney(completeJourney))
+      val result = get(routes.ConfirmationController.show.url)
+      result.status shouldBe INTERNAL_SERVER_ERROR

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/AgentJourneyExitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/AgentJourneyExitControllerISpec.scala
@@ -17,12 +17,14 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey
 
 import play.api.test.Helpers.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.AuthorisationRequest
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyExitType.NotFound
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.{ClientDetailsResponse, KnownFactType}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType, AgentJourneyType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, AgentJourneyType, JourneyExitType}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
-class AgentJourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs {
+class AgentJourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs :
 
   private val authorisationRequestJourney: AgentJourney = AgentJourney(
     AgentJourneyType.AuthorisationRequest,
@@ -48,12 +50,17 @@ class AgentJourneyExitControllerISpec extends ComponentSpecHelper with AuthStubs
 
   List(authorisationRequestJourney, agentCancelAuthorisationJourney).foreach(j =>
     JourneyExitType.values.foreach(exitType =>
-      s"GET /${j.journeyType.toString}/exit/$exitType" should {
-        "display the exit page" in {
+      s"GET /${j.journeyType.toString}/exit/$exitType" should :
+        "display the exit page" in :
           authoriseAsAgent()
           await(journeyService.saveJourney(j))
           val result = get(routes.JourneyExitController.show(j.journeyType, exitType).url)
           result.status shouldBe OK
-        }
-      }))
-}
+      ))
+
+  "a request should be redirected to ASA home when a clientService is not stored in session" in :
+    authoriseAsAgent()
+    await(journeyService.saveJourney(authorisationRequestJourney.copy(clientService = None)))
+    val result = get(routes.JourneyExitController.show(AuthorisationRequest, NotFound).url)
+    result.status shouldBe SEE_OTHER
+    result.header("Location").value shouldBe appConfig.agentServicesAccountHomeUrl

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/CheckYourAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/CheckYourAnswersControllerISpec.scala
@@ -88,45 +88,51 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with AuthStubs
     super.beforeEach()
   }
 
-  "GET /authorisation-request/confirm" should {
-    "redirect to enter client id when client details are missing" in {
+  "GET /authorisation-request/confirm" should :
+    "redirect to enter client id when client details are missing" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("personal"), clientService = Some("HMRC-MTD-IT"))))
       val result = get(routes.CheckYourAnswersController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.EnterClientIdController.show(AgentJourneyType.AuthorisationRequest).url
-    }
+
+    "redirect to ASA home if journeyComplete is defined" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, journeyComplete = Some("ABC"))))
+      val result = get(routes.CheckYourAnswersController.show(AgentJourneyType.AuthorisationRequest).url)
+      result.status shouldBe SEE_OTHER
+      result.header("Location").value shouldBe appConfig.agentServicesAccountHomeUrl
+
     servicesWithSingleAgentRole
-      .foreach(service => s"display the CYA page on authorisation request for $service journey" in {
+      .foreach(service => s"display the CYA page on authorisation request for $service journey" in :
         authoriseAsAgent()
         await(journeyService.saveJourney(singleAgentRequestJourney(service)))
         val result = get(routes.CheckYourAnswersController.show(AgentJourneyType.AuthorisationRequest).url)
         result.status shouldBe OK
-      })
+      )
     servicesWithAgentRoles
       .foreach(service => existingAgentRoles
-        .foreach(role => s"display the CYA page on authorisation request for $service journey when existing role is ${role.getOrElse("none")}" in {
+        .foreach(role => s"display the CYA page on authorisation request for $service journey when existing role is ${role.getOrElse("none")}" in :
         authoriseAsAgent()
         await(journeyService.saveJourney(agentRoleBasedRequestJourney(service, role)))
         val result = get(routes.CheckYourAnswersController.show(AgentJourneyType.AuthorisationRequest).url)
         result.status shouldBe OK
-      }))
+      ))
     servicesWithSingleAgentRole
-      .foreach(service => s"display the confirm cancellation page for $service journey" in {
+      .foreach(service => s"display the confirm cancellation page for $service journey" in :
         authoriseAsAgent()
         await(journeyService.saveJourney(existingAuthCancellationJourney(service)))
         val result = get(routes.CheckYourAnswersController.show(AgentJourneyType.AgentCancelAuthorisation).url)
         result.status shouldBe OK
-      })
+      )
     servicesWithAgentRoles
       .foreach(service => existingAgentRoles.collect({ case Some(role) => role }) // we don't test for None as it should not be possible
-        .foreach(role => s"display the confirm cancellation page for $service journey when existing role is $role" in {
+        .foreach(role => s"display the confirm cancellation page for $service journey when existing role is $role" in :
         authoriseAsAgent()
         await(journeyService.saveJourney(existingAuthCancellationJourney(service)))
         val result = get(routes.CheckYourAnswersController.show(AgentJourneyType.AgentCancelAuthorisation).url)
         result.status shouldBe OK
-      }))
-  }
+      ))
 
   "POST /authorisation-request/confirm" should {
     servicesWithSingleAgentRole.foreach(service => s"redirect to authorisation request created for $service page when confirmed" in {

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/journey/EnterClientFactControllerISpec.scala
@@ -22,17 +22,20 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney
 import uk.gov.hmrc.agentclientrelationshipsfrontend.services.AgentJourneyService
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AuthStubs, ComponentSpecHelper}
 
-class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs {
+class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs :
 
   val testNino: String = "AB123456C"
   val testPostcode: String = "AA11AA"
+  val clientDetailsResponse: ClientDetailsResponse =
+    ClientDetailsResponse("", None, None, Seq(testPostcode), Some(KnownFactType.PostalCode), false, None)
 
-  def testItsaJourney(journeyType: AgentJourneyType): AgentJourney = AgentJourney(
+  def testItsaJourney(journeyType: AgentJourneyType,
+                      clientDetails: Option[ClientDetailsResponse] = Some(clientDetailsResponse)): AgentJourney = AgentJourney(
     journeyType,
     Some("personal"),
     Some("HMRC-MTD-IT"),
     Some(testNino),
-    Some(ClientDetailsResponse("", None, None, Seq(testPostcode), Some(KnownFactType.PostalCode), false, None))
+    clientDetails
   )
 
   val journeyService: AgentJourneyService = app.injector.instanceOf[AgentJourneyService]
@@ -42,24 +45,35 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
     super.beforeEach()
   }
 
-  "GET /authorisation-request/client-fact" should {
-    "redirect to the journey start when previous answers are missing" in {
+  "GET /authorisation-request/client-fact" should :
+    "redirect to the journey start when previous answers are missing" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AuthorisationRequest, clientType = Some("personal"))))
       val result = get(routes.EnterClientFactController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AuthorisationRequest).url
-    }
-    "display the client identifier page for ITSA" in {
+
+    "return 500 when known fact type is missing" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest, Some(clientDetailsResponse.copy(knownFactType = None)))))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AuthorisationRequest).url)
+      result.status shouldBe INTERNAL_SERVER_ERROR
+
+    "display the client identifier page for ITSA" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
       val result = get(routes.EnterClientFactController.show(AgentJourneyType.AuthorisationRequest).url)
       result.status shouldBe OK
-    }
-  }
 
-  "POST /authorisation-request/client-fact" should {
-    "redirect to the next page after storing answer for ITSA" in {
+    "display the client identifier page and auto-fill the form when a known fact is in session" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest).copy(knownFact = Some("ABCNINO"))))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AuthorisationRequest).url)
+      result.status shouldBe OK
+      result.body.contains("ABCNINO") shouldBe true
+
+  "POST /authorisation-request/client-fact" should :
+    "redirect to the next page after storing answer for ITSA" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
       val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
@@ -67,8 +81,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ConfirmClientController.show(AgentJourneyType.AuthorisationRequest).url
-    }
-    "redirect to client-not-found when submitting a mismatching KF" in {
+
+    "redirect to client-not-found when submitting a mismatching KF" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
       val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
@@ -76,8 +90,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AuthorisationRequest, JourneyExitType.NotFound).url
-    }
-    "unset existing answers when submitting a new answer" in {
+
+    "unset existing answers when submitting a new answer" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest).copy(knownFact = Some("ZZ1 1AA"), clientConfirmed = Some(true))))
       post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
@@ -85,8 +99,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe None
-    }
-    "leave existing answers intact when submitting the same answer" in {
+
+    "leave existing answers intact when submitting the same answer" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest).copy(knownFact = Some(testPostcode), clientConfirmed = Some(true))))
       post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)(Map(
@@ -94,33 +108,48 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe Some(true)
-    }
-    "show an error when no selection is made" in {
+
+    "show an error when no selection is made" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest)))
       val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
       result.status shouldBe BAD_REQUEST
-    }
-  }
 
-  "GET /agent-cancel-authorisation/client-fact" should {
-    "redirect to the journey start when previous answers are missing" in {
+    "return 500 when known fact type is missing" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AuthorisationRequest, Some(clientDetailsResponse.copy(knownFactType = None)))))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AuthorisationRequest).url)("")
+      result.status shouldBe INTERNAL_SERVER_ERROR
+
+  "GET /agent-cancel-authorisation/client-fact" should :
+    "redirect to the journey start when previous answers are missing" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(AgentJourney(journeyType = AgentJourneyType.AgentCancelAuthorisation, clientType = None)))
       val result = get(routes.EnterClientFactController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.SelectClientTypeController.show(AgentJourneyType.AgentCancelAuthorisation).url
-    }
-    "display the the client identifier page for ITSA" in {
+
+    "return 500 when known fact type is missing" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation, Some(clientDetailsResponse.copy(knownFactType = None)))))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AgentCancelAuthorisation).url)
+      result.status shouldBe INTERNAL_SERVER_ERROR
+
+    "display the the client identifier page for ITSA" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
       val result = get(routes.EnterClientFactController.show(AgentJourneyType.AgentCancelAuthorisation).url)
       result.status shouldBe OK
-    }
-  }
 
-  "POST /agent-cancel-authorisation/client-fact" should {
-    "redirect to the next page after storing answer for ITSA" in {
+    "display the client identifier page and auto-fill the form when a known fact is in session" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation).copy(knownFact = Some("ABCNINO"))))
+      val result = get(routes.EnterClientFactController.show(AgentJourneyType.AgentCancelAuthorisation).url)
+      result.status shouldBe OK
+      result.body.contains("ABCNINO") shouldBe true
+
+  "POST /agent-cancel-authorisation/client-fact" should :
+    "redirect to the next page after storing answer for ITSA" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
       val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(body = Map(
@@ -128,8 +157,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ConfirmClientController.show(AgentJourneyType.AgentCancelAuthorisation).url
-    }
-    "redirect to client-not-found when submitting a mismatching KF" in {
+
+    "redirect to client-not-found when submitting a mismatching KF" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
       val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
@@ -137,8 +166,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.JourneyExitController.show(AgentJourneyType.AgentCancelAuthorisation, JourneyExitType.NotFound).url
-    }
-    "unset existing answers when submitting a new answer" in {
+
+    "unset existing answers when submitting a new answer" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation).copy(knownFact = Some("ZZ1 1AA"), clientConfirmed = Some(true))))
       post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
@@ -146,8 +175,8 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe None
-    }
-    "leave existing answers intact when submitting the same answer" in {
+
+    "leave existing answers intact when submitting the same answer" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation).copy(knownFact = Some(testPostcode), clientConfirmed = Some(true))))
       post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(Map(
@@ -155,13 +184,15 @@ class EnterClientFactControllerISpec extends ComponentSpecHelper with AuthStubs 
       ))
       val updatedJourney = await(journeyService.getJourney(request))
       updatedJourney.get.clientConfirmed shouldBe Some(true)
-    }
-    "show an error when no selection is made" in {
+
+    "show an error when no selection is made" in :
       authoriseAsAgent()
       await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation)))
       val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)(body = Map("postcode" -> Seq("")))
       result.status shouldBe BAD_REQUEST
-    }
-  }
 
-}
+    "return 500 when known fact type is missing" in :
+      authoriseAsAgent()
+      await(journeyService.saveJourney(testItsaJourney(AgentJourneyType.AgentCancelAuthorisation, Some(clientDetailsResponse.copy(knownFactType = None)))))
+      val result = post(routes.EnterClientFactController.onSubmit(AgentJourneyType.AgentCancelAuthorisation).url)("")
+      result.status shouldBe INTERNAL_SERVER_ERROR

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/ComponentSpecHelper.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/utils/ComponentSpecHelper.scala
@@ -28,6 +28,7 @@ import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie, WSRequest, WSRespo
 import play.api.mvc.{AnyContentAsFormUrlEncoded, Request, Session, SessionCookieBaker}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.crypto.PlainText
 import uk.gov.hmrc.http.SessionKeys
 import uk.gov.hmrc.play.bootstrap.frontend.filters.crypto.SessionCookieCrypto
@@ -77,6 +78,7 @@ trait ComponentSpecHelper
 
   implicit val ws: WSClient = app.injector.instanceOf[WSClient]
   implicit val executionContext: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
   override def beforeAll(): Unit = {
     startWiremock()

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -12,10 +12,11 @@ object CodeCoverageSettings {
     ".*Routes.*",
     ".*testOnly.*",
     "testOnlyDoNotUseInAppConf.*",
-    "$anon"
+    ".*\\$anon.*",
+    ".*views.html.*"
   )
 
-  val settings: Seq[Setting[_]] = Seq(
+  val settings: Seq[Setting[?]] = Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(","),
     ScoverageKeys.coverageMinimumStmtTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := true,

--- a/test/resources/testCountryList.csv
+++ b/test/resources/testCountryList.csv
@@ -1,0 +1,3 @@
+CountryISO,CountryName
+AF,Afghanistan
+AL,Albania

--- a/test/resources/testInvalidFileType.txt
+++ b/test/resources/testInvalidFileType.txt
@@ -1,0 +1,1 @@
+This is not a CSV

--- a/test/resources/testNoCountries.csv
+++ b/test/resources/testNoCountries.csv
@@ -1,0 +1,1 @@
+CountryISO,CountryName

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActionsSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActionsSpec.scala
@@ -104,134 +104,150 @@ class AuthActionsSpec extends AnyWordSpecLike with Matchers with OptionValues wi
   val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
   val testArn = "testArn"
 
-  "agentAuthAction" should {
-    "authorise an AS Agent with ARN" in {
+  "agentAuthAction" should :
+    "authorise an AS Agent with ARN" in :
       val controller = agentControllerSetup(Some(testArn))
       val result = controller.agentAuth()(fakeRequest)
 
       status(result) shouldBe OK
-    }
-    "block an AS Agent without ARN" in {
+
+    "block an AS Agent without ARN" in :
       val controller = agentControllerSetup(None)
       val result = controller.agentAuth()(fakeRequest)
 
       status(result) shouldBe FORBIDDEN
-    }
-    "redirect a user without session to the login" in {
+
+    "redirect a user without session to the login" in :
       val controller = failingControllerSetup(BearerTokenExpired(""))
       val result = controller.agentAuth()(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value should startWith("http://localhost:9099/bas-gateway/sign-in")
-    }
-    "redirect an agent without the AS enrolment to the subscription url" in {
+
+    "redirect an agent without the AS enrolment to the subscription url" in :
       val controller = failingControllerSetup(InsufficientEnrolments(""))
       val result = controller.agentAuth()(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value shouldBe "http://localhost:9437/agent-subscription/start"
-    }
-    "block an agent with the wrong auth provider" in {
+
+    "block an agent with the wrong auth provider" in :
       val controller = failingControllerSetup(UnsupportedAuthProvider(""))
       val result = controller.agentAuth()(fakeRequest)
 
       status(result) shouldBe FORBIDDEN
-    }
-  }
 
-  "clientAuthActionWithEnrolmentCheck" should {
-    s"authorise an individual client for $incomeTax with CL250" in {
+
+  "clientAuthActionWithEnrolmentCheck" should :
+    s"authorise an individual client for $incomeTax with CL250" in :
       val controller = clientControllerSetup(Individual, L250, Set(Enrolment(HMRCMTDIT)))
 
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe OK
-    }
-    s"redirect to client exit CannotFindAuthorisationRequest for $incomeTax" in {
+
+    s"redirect to client exit CannotFindAuthorisationRequest for $incomeTax" in :
       val controller = clientControllerSetup(Individual, L250, Set(Enrolment(HMRCMTDVAT)))
 
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).get shouldBe clientRoutes.ClientExitController.showClient(ClientExitType.CannotFindAuthorisationRequest).url
-    }
 
-    s"authorise an individual client for $incomeRecordViewer with CL250" in {
+
+    s"authorise an individual client for $incomeRecordViewer with CL250" in :
       val controller = clientControllerSetup(Individual, L250, Set(Enrolment(HMRCNI)))
 
       val result = controller.clientAuthWithEnrolmentCheck(incomeRecordViewer)(fakeRequest)
 
       status(result) shouldBe OK
-    }
-    s"redirect to client exit CannotFindAuthorisationRequest for $incomeRecordViewer" in {
+
+    s"redirect to client exit CannotFindAuthorisationRequest for $incomeRecordViewer" in :
       val controller = clientControllerSetup(Individual, L250, Set(Enrolment(HMRCMTDVAT)))
 
       val result = controller.clientAuthWithEnrolmentCheck(incomeRecordViewer)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).get shouldBe clientRoutes.ClientExitController.showClient(ClientExitType.CannotFindAuthorisationRequest).url
-    }
 
-    s"authorise an individual $capitalGainsTaxUkProperty client with CL50" in {
+
+    s"authorise an individual $capitalGainsTaxUkProperty client with CL50" in :
       val controller = clientControllerSetup(Individual, L50, Set(Enrolment(HMRCCGTPD)))
       val result = controller.clientAuthWithEnrolmentCheck(capitalGainsTaxUkProperty)(fakeRequest)
 
       status(result) shouldBe OK
-    }
-    "authorise an organisation client with CL50" in {
+
+    "authorise an organisation client with CL50" in :
       val controller = clientControllerSetup(Organisation, L50, Set(Enrolment(HMRCMTDVAT)))
       val result = controller.clientAuthWithEnrolmentCheck(vat)(fakeRequest)
 
       status(result) shouldBe OK
-    }
-    "authorise an organisation ITSA client with CL250" in {
+
+    "authorise an organisation ITSA client with CL250" in :
       val controller = clientControllerSetup(Organisation, L250, Set(Enrolment(HMRCMTDIT)))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe OK
-    }
-    "redirect an individual client with less than CL250 to IV" in {
+
+    "redirect an individual client with less than CL250 to IV" in :
       val controller = clientControllerSetup(Individual, L200, Set(Enrolment(HMRCMTDIT)))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value should startWith("http://localhost:9938/mdtp/uplift")
-    }
-    "redirect an organisation ITSA client with less than CL250 to IV" in {
+
+    "redirect an organisation ITSA client with less than CL250 to IV" in :
       val controller = clientControllerSetup(Organisation, L200, Set(Enrolment(HMRCMTDIT)))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value should startWith("http://localhost:9938/mdtp/uplift")
-    }
-    "redirect an agent to Cannot view request page" in {
+
+    "redirect an agent to Cannot view request page" in :
       val controller = clientControllerSetup(Agent, L50, Set(Enrolment("HMRC-AS-AGENT")))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value shouldBe
         routes.AuthorisationController.cannotViewRequest(Some(RedirectUrl(appConfig.appExternalUrl + fakeRequest.uri)), Some("income-tax")).url
-    }
-    "redirect a user without session to the login" in {
+
+    "redirect a user without session to the login" in :
       val controller = failingControllerSetup(BearerTokenExpired(""))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value should startWith("http://localhost:9099/bas-gateway/sign-in")
-    }
-    "block a client without required enrolments (can't happen in theory)" in {
+
+    "block a client without required enrolments (can't happen in theory)" in :
       val controller = failingControllerSetup(InsufficientEnrolments(""))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe FORBIDDEN
-    }
-    "block a client with the wrong auth provider" in {
+
+    "block a client with the wrong auth provider" in :
       val controller = failingControllerSetup(UnsupportedAuthProvider(""))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
 
       status(result) shouldBe FORBIDDEN
-    }
-  }
+
+    "block a client with an unsupported affinity group" in :
+      val controller = failingControllerSetup(UnsupportedAffinityGroup(""))
+      val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
+
+      status(result) shouldBe FORBIDDEN
+
+    "block a client with no affinity group" in :
+      val retrieval: Future[Option[AffinityGroup] ~ ConfidenceLevel.L250.type ~ Enrolments] =
+        Future.successful(None ~ L250 ~ Enrolments(Set(Enrolment(HMRCMTDIT))))
+      val controller = new FakeController(
+        new AuthActions(FakePassingAuthConnector(retrieval), appConfig, serviceConfig),
+        defaultActionBuilder
+      )
+      val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)
+
+      status(result) shouldBe FORBIDDEN
+
+
 
   "clientAuthAction" should:
 
@@ -292,6 +308,23 @@ class AuthActionsSpec extends AnyWordSpecLike with Matchers with OptionValues wi
     "block a client with the wrong auth provider" in:
       val controller = failingControllerSetup(UnsupportedAuthProvider(""))
       val result = controller.clientAuth()(fakeRequest)
+      status(result) shouldBe FORBIDDEN
+
+    "block a client with an unsupported affinity group" in :
+      val controller = failingControllerSetup(UnsupportedAffinityGroup(""))
+      val result = controller.clientAuth()(fakeRequest)
+
+      status(result) shouldBe FORBIDDEN
+
+    "block a client with no affinity group" in :
+      val retrieval: Future[Option[AffinityGroup] ~ ConfidenceLevel.L250.type ~ Enrolments] =
+        Future.successful(None ~ L250 ~ Enrolments(Set(Enrolment(HMRCMTDIT))))
+      val controller = new FakeController(
+        new AuthActions(FakePassingAuthConnector(retrieval), appConfig, serviceConfig),
+        defaultActionBuilder
+      )
+      val result = controller.clientAuth()(fakeRequest)
+
       status(result) shouldBe FORBIDDEN
 }
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/config/CountryNamesLoaderSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/config/CountryNamesLoaderSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.config
+
+import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.collection.immutable.ListMap
+
+class CountryNamesLoaderSpec extends AnyWordSpecLike with Matchers with MockitoSugar :
+
+  implicit val mockAppConfig: AppConfig = mock[AppConfig]
+  def countryNamesLoader = new CountryNamesLoader()
+
+  ".load" should :
+
+    "return a ListMap of countries when the CSV file is loaded and parsed correctly" in :
+      when(mockAppConfig.countryListLocation).thenReturn("/testCountryList.csv")
+      countryNamesLoader.load shouldBe ListMap("AF" -> "Afghanistan", "AL" -> "Albania")
+
+    "return an exception" when :
+
+      "the CSV file is loaded but no countries were parsed" in :
+        when(mockAppConfig.countryListLocation).thenReturn("/testNoCountries.csv")
+        intercept[RuntimeException](countryNamesLoader.load).getMessage shouldBe "No country codes or names found"
+
+      "the file path is empty" in :
+        when(mockAppConfig.countryListLocation).thenReturn("")
+        intercept[RuntimeException](countryNamesLoader.load).getMessage shouldBe
+          "requirement failed: The country list path should not be empty"
+
+      "the target file is not a CSV type" in :
+        when(mockAppConfig.countryListLocation).thenReturn("/testInvalidFileType.txt")
+        intercept[RuntimeException](countryNamesLoader.load).getMessage shouldBe
+          "requirement failed: The country list file should be a csv file"

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AgentDetailsSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/AgentDetailsSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.libs.json.{JsObject, Json}
+
+class AgentDetailsSpec extends AnyWordSpecLike with Matchers :
+
+  "AgentDetails" should :
+
+    "read from JSON" when :
+
+      "all fields are present" in :
+        val json: JsObject = Json.obj("agencyDetails" -> Json.obj("agencyName" -> "ABC Accountants", "agencyEmail" -> "abc@test.com"))
+        val model: AgentDetails = AgentDetails("ABC Accountants", "abc@test.com")
+
+        json.as[AgentDetails] shouldBe model
+
+      "agencyName is not present" in :
+        val json: JsObject = Json.obj("agencyDetails" -> Json.obj("agencyEmail" -> "abc@test.com"))
+        val model: AgentDetails = AgentDetails("", "abc@test.com")
+
+        json.as[AgentDetails] shouldBe model
+
+      "agencyEmail is not present" in :
+        val json: JsObject = Json.obj("agencyDetails" -> Json.obj("agencyName" -> "ABC Accountants"))
+        val model: AgentDetails = AgentDetails("ABC Accountants", "")
+
+        json.as[AgentDetails] shouldBe model
+
+      "an expected field is null" in :
+        val json: JsObject = Json.obj("agencyDetails" -> Json.obj("agencyEmail" -> "abc@test.com", "agencyName" -> null))
+        val model: AgentDetails = AgentDetails("", "abc@test.com")
+
+        json.as[AgentDetails] shouldBe model
+
+      "an expected field is an unexpected type" in :
+        val json: JsObject = Json.obj("agencyDetails" -> Json.obj("agencyName" -> true, "agencyEmail" -> "abc@test.com"))
+        val model: AgentDetails = AgentDetails("", "abc@test.com")
+
+        json.as[AgentDetails] shouldBe model
+
+      "no fields are present" in :
+        val json: JsObject = Json.obj("agencyDetails" -> Json.obj())
+        val model: AgentDetails = AgentDetails("", "")
+
+        json.as[AgentDetails] shouldBe model
+
+    "write to JSON" in :
+      val model: AgentDetails = AgentDetails("ABC Accountants", "abc@test.com")
+      val json: JsObject = Json.obj("agencyName" -> "ABC Accountants", "agencyEmail" -> "abc@test.com")
+
+      Json.toJson(model) shouldBe json

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/client/InvitationStatusSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/client/InvitationStatusSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.client
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.libs.json.{JsString, Json}
+
+class InvitationStatusSpec extends AnyWordSpecLike with Matchers :
+
+  "InvitationStatus" should :
+
+    "instantiate from a recognised String" in :
+      InvitationStatus("Pending") shouldBe Pending
+      InvitationStatus("Rejected") shouldBe Rejected
+      InvitationStatus("Accepted") shouldBe Accepted
+      InvitationStatus("Cancelled") shouldBe Cancelled
+      InvitationStatus("Expired") shouldBe Expired
+      InvitationStatus("Deauthorised") shouldBe DeAuthorised
+      InvitationStatus("Partialauth") shouldBe PartialAuth
+
+    "fail to instantiate when the provided value is not recognised" in :
+      intercept[IllegalArgumentException](InvitationStatus("Destroyed"))
+
+    "unapply to a String" in :
+      InvitationStatus.unapply(Pending) shouldBe "Pending"
+      InvitationStatus.unapply(Rejected) shouldBe "Rejected"
+      InvitationStatus.unapply(Accepted) shouldBe "Accepted"
+      InvitationStatus.unapply(Cancelled) shouldBe "Cancelled"
+      InvitationStatus.unapply(Expired) shouldBe "Expired"
+      InvitationStatus.unapply(DeAuthorised) shouldBe "Deauthorised"
+      InvitationStatus.unapply(PartialAuth) shouldBe "Partialauth"
+
+    "read from JSON when the status is recognised" in :
+      JsString("Pending").as[InvitationStatus] shouldBe Pending
+      JsString("Rejected").as[InvitationStatus] shouldBe Rejected
+      JsString("Accepted").as[InvitationStatus] shouldBe Accepted
+      JsString("Cancelled").as[InvitationStatus] shouldBe Cancelled
+      JsString("Expired").as[InvitationStatus] shouldBe Expired
+      JsString("Deauthorised").as[InvitationStatus] shouldBe DeAuthorised
+      JsString("Partialauth").as[InvitationStatus] shouldBe PartialAuth
+
+    "fail to read from JSON when the status is not recognised" in :
+      intercept[IllegalArgumentException](JsString("Destroyed").as[InvitationStatus])
+
+    "write to JSON" in :
+      Json.toJson(InvitationStatus("Pending")) shouldBe JsString("Pending")
+      Json.toJson(InvitationStatus("Rejected")) shouldBe JsString("Rejected")
+      Json.toJson(InvitationStatus("Accepted")) shouldBe JsString("Accepted")
+      Json.toJson(InvitationStatus("Cancelled")) shouldBe JsString("Cancelled")
+      Json.toJson(InvitationStatus("Expired")) shouldBe JsString("Expired")
+      Json.toJson(InvitationStatus("Deauthorised")) shouldBe JsString("Deauthorised")
+      Json.toJson(InvitationStatus("Partialauth")) shouldBe JsString("Partialauth")

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/EnterClientFactFormSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/EnterClientFactFormSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.KnownFactsConfiguration
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.journey.EnterClientFactForm
+
+
+class EnterClientFactFormSpec extends AnyWordSpecLike with Matchers :
+
+  "The EnterClientFactForm" should :
+
+    "have the correct form mapping type" when :
+
+      "the input type is 'date'" in :
+        val fieldConfig: KnownFactsConfiguration = KnownFactsConfiguration("fieldName", "", "date", 1, None)
+        val form = EnterClientFactForm.form(fieldConfig, "service", Set())
+        val result = form.bind(Map("fieldName.day" -> "11", "fieldName.month" -> "11", "fieldName.year" -> "2000"))
+        result.hasErrors shouldBe false
+
+      "the input type is 'select'" in :
+        val fieldConfig: KnownFactsConfiguration = KnownFactsConfiguration("fieldName", "", "select", 1, Some(Seq("AL" -> "Albania")))
+        val form = EnterClientFactForm.form(fieldConfig, "service", Set("AL"))
+        val result = form.bind(Map("fieldName" -> "AL"))
+        result.hasErrors shouldBe false
+
+      "the input type is 'text'" in :
+        val fieldConfig: KnownFactsConfiguration = KnownFactsConfiguration("fieldName", "[A-Z]{3}", "text", 3, None)
+        val form = EnterClientFactForm.form(fieldConfig, "service", Set())
+        val result = form.bind(Map("fieldName" -> "ABC"))
+        result.hasErrors shouldBe false
+
+    "throw an exception" when :
+
+      "the input type is unrecognised" in :
+        val fieldConfig: KnownFactsConfiguration = KnownFactsConfiguration("fieldName", "", "music", 1, None)
+        intercept[RuntimeException](EnterClientFactForm.form(fieldConfig, "service", Set()))

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/TextFormFieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/models/forms/helpers/TextFormFieldHelperSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.models.forms.helpers
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.data.Forms.single
+import play.api.data.{Form, FormError, Mapping}
+
+import scala.collection.immutable.ArraySeq
+
+class TextFormFieldHelperSpec extends AnyWordSpec with Matchers :
+
+  val fieldName = "fieldName"
+  val messageKey = "messageKey"
+  val exampleRegex = "[A-Z]{3}"
+  val formMapping: Mapping[String] = TextFormFieldHelper.textFieldMapping(fieldName, messageKey, exampleRegex)
+  val exampleForm: Form[String] = Form(single(fieldName -> formMapping))
+
+  "The text form field helper" should :
+
+    "validate a text field when the value adheres to the regex" in :
+      val result = exampleForm.bind(Map(fieldName -> "ABC"))
+      result.hasErrors shouldBe false
+
+    "invalidate a text field when the value does not adhere to the regex" in :
+      val result = exampleForm.bind(Map(fieldName -> "ABC23495302965"))
+      result.hasErrors shouldBe true
+      result.errors.head shouldBe FormError("fieldName", List("messageKey.error.invalid"), ArraySeq(("inputFieldClass", "fieldName")))
+
+    "invalidate a text field when the value is empty" in :
+      val result = exampleForm.bind(Map(fieldName -> ""))
+      result.hasErrors shouldBe true
+      result.errors.head shouldBe FormError("fieldName", List("messageKey.error.required"), ArraySeq(("inputFieldClass", "fieldName")))

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/modules/CryptoProviderModuleSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/modules/CryptoProviderModuleSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.modules
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.Configuration
+import uk.gov.hmrc.crypto.{Crypted, PlainBytes, PlainText}
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class CryptoProviderModuleSpec extends AnyWordSpecLike with Matchers :
+
+  val cryptoProviderModule = new CryptoProviderModule
+
+  "CryptoProviderModule.aesGcmCryptoInstance" should :
+
+    "return a real crypto instance when the 'mongoEncryption' config flag is enabled" in :
+      val config = Configuration("mongoEncryption.key" -> "123", "mongoEncryption.enable" -> true)
+      cryptoProviderModule.aesGcmCryptoInstance(config) should not be a[NoCrypto.type]
+
+    "return a NoCrypto instance when the 'mongoEncryption' config flag is disabled" in :
+      val config = Configuration("mongoEncryption.enable" -> false)
+      cryptoProviderModule.aesGcmCryptoInstance(config) shouldBe a[NoCrypto.type]
+
+  "NoCrypto" should :
+
+    val text = "Not a secret"
+    val bytes: Array[Byte] = Array(0x13, 0x37)
+    val base64Bytes = new String(Base64.getEncoder.encode(bytes), StandardCharsets.UTF_8)
+
+    "apply no encryption to plain text content" in :
+      NoCrypto.encrypt(PlainText(text)).value shouldBe text
+
+    "apply no encryption to plain text bytes (base64 encoded)" in :
+      NoCrypto.encrypt(PlainBytes(bytes)).value shouldBe base64Bytes
+
+    "return the plain text from a provided Crypted instance" in :
+      NoCrypto.decrypt(Crypted(text)).value shouldBe text
+
+    "return the plain bytes from a provided Crypted instance" in :
+      NoCrypto.decryptAsBytes(Crypted(base64Bytes)).value shouldBe bytes

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentJourneyServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AgentJourneyServiceSpec.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.services
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.mockito.stubbing.OngoingStubbing
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.Reads
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.HMRCMTDVAT
+import uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.journey.routes
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.ClientDetailsResponse
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.ClientStatus.Insolvent
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.KnownFactType.Date
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourney, JourneyExitType}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.AgentJourneyType.{AgentCancelAuthorisation, AuthorisationRequest}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.JourneyExitType.ClientStatusInsolvent
+import uk.gov.hmrc.agentclientrelationshipsfrontend.repositories.JourneyRepository
+import uk.gov.hmrc.mongo.cache.DataKey
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class AgentJourneyServiceSpec extends AnyWordSpecLike with Matchers with MockitoSugar with BeforeAndAfterEach :
+
+  val mockJourneyRepo: JourneyRepository = mock[JourneyRepository]
+  val mockClientServiceConfigService: ClientServiceConfigurationService = mock[ClientServiceConfigurationService]
+  implicit val mockAppConfig: AppConfig = mock[AppConfig]
+  val service = new AgentJourneyService(mockJourneyRepo, mockClientServiceConfigService)
+  val baseAgentJourney: AgentJourney = AgentJourney(AuthorisationRequest)
+  val arn = "XARN1234567"
+  implicit val fakeRequest: FakeRequest[?] = FakeRequest()
+
+  def givenJourneyInSession(sessionJourney: AgentJourney): OngoingStubbing[Future[Option[AgentJourney]]] =
+    when(mockJourneyRepo.getFromSession(any[DataKey[AgentJourney]]())(using any[Reads[AgentJourney]](), any[RequestHeader]()))
+    .thenReturn(Future.successful(Some(sessionJourney)))
+
+  override def beforeEach(): Unit = {
+    reset(mockJourneyRepo, mockClientServiceConfigService)
+  }
+
+  ".nextPageUrl" should :
+
+    "return the Start URL when there is no journey in session" in :
+      when(mockJourneyRepo.getFromSession(any[DataKey[AgentJourney]]())(using any[Reads[AgentJourney]](), any[RequestHeader]()))
+        .thenReturn(Future.successful(None))
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.StartJourneyController.startJourney(AuthorisationRequest).url
+
+    "return the Start URL when journey type does not match" in :
+      val sessionJourney = baseAgentJourney.copy(journeyType = AgentCancelAuthorisation)
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.StartJourneyController.startJourney(AuthorisationRequest).url
+
+    "return the ASA home URL when journeyComplete is present" in :
+      val sessionJourney = baseAgentJourney.copy(journeyComplete = Some("ABC123"))
+      givenJourneyInSession(sessionJourney)
+      when(mockAppConfig.agentServicesAccountHomeUrl).thenReturn("/asa-home")
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe mockAppConfig.agentServicesAccountHomeUrl
+
+    "return the SelectClientType URL when clientService is empty" in :
+      val sessionJourney = baseAgentJourney
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.SelectClientTypeController.show(AuthorisationRequest).url
+
+    "return the ServiceRefinement URL if the clientService needs refining" in :
+      val sessionJourney = baseAgentJourney.copy(clientService = Some(HMRCMTDVAT))
+      givenJourneyInSession(sessionJourney)
+      when(mockClientServiceConfigService.requiresRefining(any[String]())).thenReturn(true)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.ServiceRefinementController.show(AuthorisationRequest).url
+
+    "return the EnterClientId URL if there is no existing ID for the clientService" in :
+      val sessionJourney = baseAgentJourney.copy(clientService = Some(HMRCMTDVAT))
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.EnterClientIdController.show(AuthorisationRequest).url
+
+    "return the EnterClientFact URL if there is no existing known fact for the provided client" in :
+      val sessionJourney = baseAgentJourney.copy(
+        clientService = Some(HMRCMTDVAT),
+        clientDetailsResponse = Some(ClientDetailsResponse("Colin Client", None, None, Seq(), Some(Date), false, None))
+      )
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.EnterClientFactController.show(AuthorisationRequest).url
+
+    "return the ConfirmClient URL if the provided client details have not been confirmed yet" in :
+      val sessionJourney = baseAgentJourney.copy(
+        clientService = Some(HMRCMTDVAT),
+        clientDetailsResponse = Some(ClientDetailsResponse("Colin Client", None, None, Seq(), Some(Date), false, None)),
+        knownFact = Some("2020-01-01")
+      )
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.ConfirmClientController.show(AuthorisationRequest).url
+
+    "return the Start URL if the clientConfirmed is defined but set to false" in :
+      val sessionJourney = baseAgentJourney.copy(
+        clientService = Some(HMRCMTDVAT),
+        clientDetailsResponse = Some(ClientDetailsResponse("Colin Client", None, None, Seq(), Some(Date), false, None)),
+        knownFact = Some("2020-01-01"),
+        clientConfirmed = Some(false)
+      )
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.StartJourneyController.startJourney(AuthorisationRequest).url
+
+    "return the AgentRole URL if the provided client details are confirmed and the service supports agent roles" in :
+      val sessionJourney = baseAgentJourney.copy(
+        clientService = Some(HMRCMTDVAT),
+        clientDetailsResponse = Some(ClientDetailsResponse("Colin Client", None, None, Seq(), Some(Date), false, None)),
+        knownFact = Some("2020-01-01"),
+        clientConfirmed = Some(true)
+      )
+      when(mockClientServiceConfigService.supportsAgentRoles(any[String]())).thenReturn(true)
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.SelectAgentRoleController.show(AuthorisationRequest).url
+
+    "return an exit page URL if the session indicates there is an exit reason" in :
+      val sessionJourney = baseAgentJourney.copy(
+        clientService = Some(HMRCMTDVAT),
+        clientDetailsResponse = Some(ClientDetailsResponse("Colin Client", Some(Insolvent), None, Seq(), Some(Date), false, None)),
+        knownFact = Some("2020-01-01"),
+        clientConfirmed = Some(true),
+        agentType = Some("main")
+      )
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.JourneyExitController.show(AuthorisationRequest, ClientStatusInsolvent).url
+
+    "return the CheckYourAnswers URL if all necessary values are defined and there is no reason to exit" in :
+      val sessionJourney = baseAgentJourney.copy(
+        clientService = Some(HMRCMTDVAT),
+        clientDetailsResponse = Some(ClientDetailsResponse("Colin Client", None, None, Seq(), Some(Date), false, None)),
+        knownFact = Some("2020-01-01"),
+        clientConfirmed = Some(true),
+        agentType = Some("main")
+      )
+      givenJourneyInSession(sessionJourney)
+
+      val result = await(service.nextPageUrl(AuthorisationRequest))
+      result shouldBe routes.CheckYourAnswersController.show(AuthorisationRequest).url

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AuthorisationsCacheServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/AuthorisationsCacheServiceSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationshipsfrontend.services
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.Reads
+import play.api.mvc.{AnyContentAsEmpty, RequestHeader}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{Authorisation, AuthorisationsCache}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.repositories.AuthorisationsCacheRepository
+import uk.gov.hmrc.mongo.cache.DataKey
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class AuthorisationsCacheServiceSpec extends AnyWordSpecLike with Matchers with MockitoSugar :
+
+  val mockSessionRepo: AuthorisationsCacheRepository = mock[AuthorisationsCacheRepository]
+  val service = new AuthorisationsCacheService(mockSessionRepo)
+
+  ".getAuthorisation" should :
+
+    "return an authorisation when one is found in the session cache repository" in :
+      val authorisation = Authorisation(
+        "testUid",
+        "HMRC-MTD-IT",
+        "testNino",
+        LocalDate.now(),
+        "testArn",
+        "testAgentName"
+      )
+      when(mockSessionRepo.getFromSession(any[DataKey[AuthorisationsCache]]())(using any[Reads[AuthorisationsCache]](), any[RequestHeader]()))
+        .thenReturn(Future.successful(Some(AuthorisationsCache(Seq(authorisation)))))
+      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+
+      await(service.getAuthorisation("testUid")) shouldBe Some(authorisation)
+
+    "return None when an authorisation could not be found in the session cache repository" in :
+      when(mockSessionRepo.getFromSession(any[DataKey[AuthorisationsCache]]())(using any[Reads[AuthorisationsCache]](), any[RequestHeader]()))
+        .thenReturn(Future.successful(None))
+      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+
+      await(service.getAuthorisation("testUid")) shouldBe None

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
@@ -18,51 +18,161 @@ package uk.gov.hmrc.agentclientrelationshipsfrontend.services
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.common.ClientDetailsConfiguration
 
-class ClientServiceConfigurationServiceSpec(implicit val appConfig: AppConfig) extends AnyWordSpecLike with Matchers with ServiceConstants {
+class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matchers with ServiceConstants with MockitoSugar :
 
+  implicit val appConfig: AppConfig = mock[AppConfig]
   val services = new ClientServiceConfigurationService
   val serviceNames: List[String] = List(incomeTax, vat, capitalGainsTaxUkProperty, plasticPackagingTax, pillar2, trustsAndEstates, trustsAndEstateNonTaxable, incomeRecordViewer, countryByCountryReporting)
 
-  "getServiceKeysForUrlPart" should {
-    s"return enrolments supported by $incomeTax" in {
+  "getServiceKeysForUrlPart" should :
+
+    s"return enrolments supported by $incomeTax" in :
       services.getServiceKeysForUrlPart(incomeTax) shouldBe Set(HMRCMTDIT, HMRCNI, HMRCPT)
-    }
-    s"return enrolments supported by $vat" in {
+
+    s"return enrolments supported by $vat" in :
       services.getServiceKeysForUrlPart(vat) shouldBe Set(HMRCMTDVAT)
-    }
-    s"return enrolments supported by $capitalGainsTaxUkProperty" in {
+
+    s"return enrolments supported by $capitalGainsTaxUkProperty" in :
       services.getServiceKeysForUrlPart(capitalGainsTaxUkProperty) shouldBe Set(HMRCCGTPD)
-    }
-    s"return enrolments supported by $trustsAndEstates" in {
+
+    s"return enrolments supported by $trustsAndEstates" in :
       services.getServiceKeysForUrlPart(trustsAndEstates) shouldBe Set(HMRCTERSORG, HMRCTERSNTORG)
-    }
-    s"return enrolments supported by $pillar2" in {
+
+    s"return enrolments supported by $pillar2" in :
       services.getServiceKeysForUrlPart(pillar2) shouldBe Set(HMRCPILLAR2ORG)
-    }
-    s"return enrolments supported by $incomeRecordViewer" in {
+
+    s"return enrolments supported by $incomeRecordViewer" in :
       services.getServiceKeysForUrlPart(incomeRecordViewer) shouldBe Set(HMRCNI, HMRCPT)
-    }
-    s"return enrolments supported by $plasticPackagingTax" in {
+
+    s"return enrolments supported by $plasticPackagingTax" in :
       services.getServiceKeysForUrlPart(plasticPackagingTax) shouldBe Set(HMRCPPTORG)
-    }
-    s"return enrolments supported by $countryByCountryReporting" in {
+
+    s"return enrolments supported by $countryByCountryReporting" in :
       services.getServiceKeysForUrlPart(countryByCountryReporting) shouldBe Set(HMRCCBCORG, HMRCCBCNONUKORG)
-    }
-    "return an empty Set when service is unknown" in {
+
+    "return an empty Set when service is unknown" in :
       services.getServiceKeysForUrlPart("unknown") shouldBe Set()
-    }
-  }
-  "inferredClientType" should {
-    "return an inferred client type for services with only one type supported" in {
+
+
+
+  "inferredClientType" should :
+
+    "return an inferred client type for services with only one type supported" in :
       services.inferredClientType(HMRCMTDIT) shouldBe Some("personal")
-    }
-    "return personal for personal income record" in {
+
+    "return personal for personal income record" in :
       services.inferredClientType(PERSONALINCOMERECORD) shouldBe Some("personal")
-    }
-    "return None for services with more than one client type supported" in {
+
+    "return None for services with more than one client type supported" in :
       services.inferredClientType(HMRCMTDVAT) shouldBe None
-    }
-  }
-}
+
+
+  "allClientTypes" should :
+
+    "return the supported client types across all services" in :
+      services.allClientTypes shouldBe Set("personal", "business", "trust")
+
+  "clientDetailsFor" should :
+
+    s"provide the correct client details for $HMRCMTDIT" in :
+      services.clientDetailsFor(HMRCMTDIT) shouldBe Seq(ClientDetailsConfiguration(
+        name = "nino",
+        regex = "[[A-Z]&&[^DFIQUV]][[A-Z]&&[^DFIQUVO]] ?\\d{2} ?\\d{2} ?\\d{2} ?[A-D]{1}",
+        inputType = "text",
+        width = 10,
+        clientIdType = "ni"
+      ))
+
+    s"provide the correct client details for $HMRCMTDITSUPP" in :
+      services.clientDetailsFor(HMRCMTDITSUPP) shouldBe Seq(ClientDetailsConfiguration(
+        name = "nino",
+        regex = "[[A-Z]&&[^DFIQUV]][[A-Z]&&[^DFIQUVO]] ?\\d{2} ?\\d{2} ?\\d{2} ?[A-D]{1}",
+        inputType = "text",
+        width = 10,
+        clientIdType = "ni"
+      ))
+
+    s"provide the correct client details for $PERSONALINCOMERECORD" in :
+      services.clientDetailsFor(PERSONALINCOMERECORD) shouldBe Seq(ClientDetailsConfiguration(
+        name = "nino",
+        regex = "[[A-Z]&&[^DFIQUV]][[A-Z]&&[^DFIQUVO]] ?\\d{2} ?\\d{2} ?\\d{2} ?[A-D]{1}",
+        inputType = "text",
+        width = 10,
+        clientIdType = "ni"
+      ))
+
+    s"provide the correct client details for $HMRCMTDVAT" in :
+      services.clientDetailsFor(HMRCMTDVAT) shouldBe Seq(ClientDetailsConfiguration(
+        name = "vrn",
+        regex = "^[0-9]{9}$",
+        inputType = "text",
+        width = 10,
+        clientIdType = "vrn"
+      ))
+
+    s"provide the correct client details for $HMRCTERSORG" in :
+      services.clientDetailsFor(HMRCTERSORG) shouldBe Seq(ClientDetailsConfiguration(
+        name = "utr",
+        regex = "^[0-9]{10}$",
+        inputType = "text",
+        width = 10,
+        clientIdType = "utr"
+      ))
+
+    s"provide the correct client details for $HMRCTERSNTORG" in :
+      services.clientDetailsFor(HMRCTERSNTORG) shouldBe Seq(ClientDetailsConfiguration(
+        name = "urn",
+        regex = "^[A-Z]{2}TRUST[0-9]{8}$",
+        inputType = "text",
+        width = 20,
+        clientIdType = "urn"
+      ))
+
+    s"provide the correct client details for $HMRCCGTPD" in :
+      services.clientDetailsFor(HMRCCGTPD) shouldBe Seq(ClientDetailsConfiguration(
+        name = "cgtRef",
+        regex = "^X[A-Z]CGTP[0-9]{9}$",
+        inputType = "text",
+        width = 20,
+        clientIdType = "CGTPDRef"
+      ))
+
+    s"provide the correct client details for $HMRCPPTORG" in :
+      services.clientDetailsFor(HMRCPPTORG) shouldBe Seq(ClientDetailsConfiguration(
+        name = "pptRef",
+        regex = "^X[A-Z]PPT000[0-9]{7}$",
+        inputType = "text",
+        width = 20,
+        clientIdType = "EtmpRegistrationNumber"
+      ))
+
+    s"provide the correct client details for $HMRCCBCORG" in :
+      services.clientDetailsFor(HMRCCBCORG) shouldBe Seq(ClientDetailsConfiguration(
+        name = "cbcId",
+        regex = "^X[A-Z]CBC[0-9]{10}$",
+        inputType = "text",
+        width = 20,
+        clientIdType = "cbcId"
+      ))
+
+    s"provide the correct client details for $HMRCCBCNONUKORG" in :
+      services.clientDetailsFor(HMRCCBCNONUKORG) shouldBe Seq(ClientDetailsConfiguration(
+        name = "cbcId",
+        regex = "^X[A-Z]CBC[0-9]{10}$",
+        inputType = "text",
+        width = 20,
+        clientIdType = "cbcId"
+      ))
+
+    s"provide the correct client details for $HMRCPILLAR2ORG" in :
+      services.clientDetailsFor(HMRCPILLAR2ORG) shouldBe Seq(ClientDetailsConfiguration(
+        name = "PlrId",
+        regex = "^X[A-Z]{1}PLR[0-9]{10}$",
+        inputType = "text",
+        width = 20,
+        clientIdType = "PLRID"
+      ))


### PR DESCRIPTION
Statement coverage improved from 90.49% -> 95.34%
Branch coverage improved from 78.03% -> 85.68%

The change to the auth actions was to remove the `case _` when matching on AffinityGroup as this was impossible to reach, and replace it with handling an `UnsupportedAffinityGroup` exception.