### PR TITLE
APB-9321 fix bug in MYTA link generation for variant services

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
@@ -85,7 +85,7 @@ class ClientServiceConfigurationService @Inject()(implicit appConfig: AppConfig)
     .getOrElse(Set())
 
   // url parts are used in public urls to determine which service
-  def getUrlPart(clientService: String): String = services(getServiceForForm(clientService)).urlPart.head._1
+  def getUrlPart(clientService: String): String = services(getServiceForForm(clientService)).urlPart.keys.head
 
   // when a service only supports one client type we can infer the client type from the service when it's missing
   // from any fast track requests

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPage.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
+@import uk.gov.hmrc.agentclientrelationshipsfrontend.services.ClientServiceConfigurationService
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.{Authorisation, ManageYourTaxAgentsData}
 @import uk.gov.hmrc.agentclientrelationshipsfrontend.models.Invitation
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcNewTabLinkHelper
@@ -30,7 +31,8 @@
         govukTabs: GovukTabs,
         govukTable: GovukTable,
         h1: h1,
-        hmrcNewTabLinkHelper: HmrcNewTabLinkHelper
+        hmrcNewTabLinkHelper: HmrcNewTabLinkHelper,
+        clientServiceConfig: ClientServiceConfigurationService
 )
 
 @(supportedServices: Map[String, String], data: ManageYourTaxAgentsData)(implicit request: Request[?], messages: Messages, appConfig: AppConfig)
@@ -53,11 +55,11 @@
 }
 @agentRoleFromService(service: String) = @{
     if(!appConfig.emaEnabled) ""
-    else if(service == "HMRC-MTD-IT-SUPP") messages(s"$key.agentRole.supporting")
+    else if(messages.isDefinedAt(s"$key.agentRole.$service")) messages(s"$key.agentRole.$service")
     else messages(s"$key.agentRole.main")
 }
 @linkFromService(uid: String, service: String, agentName: String) = {
-    <a href="@{routes.ConsentInformationController.show(uid, supportedServices(service)).url}" class="govuk-link">
+    <a href="@{routes.ConsentInformationController.show(uid, supportedServices(clientServiceConfig.getServiceForForm(service))).url}" class="govuk-link">
         @Html(messages(s"$key.currentRequests.action.link", agentName, messages(service), agentRoleFromService(service)))
     </a>
 }

--- a/conf/messages
+++ b/conf/messages
@@ -803,7 +803,8 @@ manageYourTaxAgents.agentRoles.p2=You can also have ‘supporting’ agents help
 manageYourTaxAgents.agentRoles.guidanceLink=Find out how main and supporting agents can act for you
 
 manageYourTaxAgents.agentRole.main=Main
-manageYourTaxAgents.agentRole.supporting=Supporting
+manageYourTaxAgents.agentRole.HMRC-MTD-IT=Main
+manageYourTaxAgents.agentRole.HMRC-MTD-IT-SUPP=Supporting
 
 manageYourTaxAgents.currentRequests=Current requests
 manageYourTaxAgents.currentRequests.taxService=Tax service

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ManageYourTaxAgentsPageSpec.scala
@@ -81,16 +81,32 @@ class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
         agentName = agentName,
         invitations = Seq(
           Invitation(
-            invitationId = "1234567890",
-            service = "HMRC-MTD-IT",
+            invitationId = "4454567890",
+            service = "HMRC-MTD-IT-SUPP",
             clientName = "Some test",
             status = Pending,
             expiryDate = expiryDate,
             lastUpdated = Instant.now()
           ),
           Invitation(
-            invitationId = "123LD67891",
+            invitationId = "336LD67891",
             service = "HMRC-PILLAR2-ORG",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = expiryDate,
+            lastUpdated = Instant.now()
+          ),
+          Invitation(
+            invitationId = "456LD67891",
+            service = "HMRC-TERSNT-ORG",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = expiryDate,
+            lastUpdated = Instant.now()
+          ),
+          Invitation(
+            invitationId = "456LD67891",
+            service = "HMRC-CBC-NONUK-ORG",
             clientName = "Some test",
             status = Pending,
             expiryDate = expiryDate,
@@ -102,6 +118,14 @@ class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
         uid = "1234590",
         agentName = agentName2,
         invitations = Seq(
+          Invitation(
+            invitationId = "7714567891",
+            service = "HMRC-MTD-IT",
+            clientName = "Some test",
+            status = Pending,
+            expiryDate = expiryDate,
+            lastUpdated = Instant.now()
+          ),
           Invitation(
             invitationId = "123456BFX90",
             service = "HMRC-MTD-VAT",
@@ -214,20 +238,38 @@ class ManageYourTaxAgentsPageSpec extends ViewSpecSupport {
         rows = List(
           IndexedSeq(
             "Making Tax Digital for Income Tax",
-            "Main",
+            "Supporting",
             expiryDate.format(dateFormatter),
-            s"Respond to request from $agentName to manage your Making Tax Digital for Income Tax as a Main agent"
+            s"Respond to request from $agentName to manage your Making Tax Digital for Income Tax as a Supporting agent"
           ),
           IndexedSeq(
             "Pillar 2 Top-up Taxes",
             "Main",
             expiryDate.format(dateFormatter),
             s"Respond to request from $agentName to manage your Pillar 2 Top-up Taxes as a Main agent"
+          ),
+          IndexedSeq(
+            "Trusts and Estates",
+            "Main",
+            expiryDate.format(dateFormatter),
+            s"Respond to request from $agentName to manage your Trusts and Estates as a Main agent"
+          ),
+          IndexedSeq(
+            "Country-by-country reporting",
+            "Main",
+            expiryDate.format(dateFormatter),
+            s"Respond to request from $agentName to manage your Country-by-country reporting as a Main agent"
           )
         ))
       doc.mainContent.extractTable(2, 4).value shouldBe TestTable(
         caption = agentName2,
         rows = List(
+          IndexedSeq(
+            "Making Tax Digital for Income Tax",
+            "Main",
+            expiryDate.format(dateFormatter),
+            s"Respond to request from $agentName2 to manage your Making Tax Digital for Income Tax as a Main agent"
+          ),
           IndexedSeq(
             "VAT",
             "Main",


### PR DESCRIPTION
Used the clientServiceConfig method `getServiceForForm` when matching the service from an invitation to the list of enabled services available in the MYTA template, which is actually the same list as in the auth/deauth form to select service options - hence this extra refinement needed to catch when invitations are for services not in that list (currently HMRC-MTD-IT-SUPP, HMRC-TERSNT-ORG and HMRC-CBCNONUK-ORG - these all are "variants" of a service option).

Also found a rogue use of a service key in template logic - so fixed that by being declarative with the message keys instead.

Tests updated to prove "variant" services are supported.