### PR TITLE
APB-9134 fix call to client details and missing msgs

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/connectors/AgentClientRelationshipsConnector.scala
@@ -43,7 +43,7 @@ class AgentClientRelationshipsConnector @Inject()(appConfig: AppConfig,
   private val agentClientRelationshipsUrl = s"${appConfig.agentClientRelationshipsBaseUrl}/agent-client-relationships"
 
   def getClientDetails(service: String, clientId: String)(implicit hc: HeaderCarrier): Future[Option[ClientDetailsResponse]] = httpV2
-    .get(url"$agentClientRelationshipsUrl/client/$service/details/$clientId")
+    .get(url"$agentClientRelationshipsUrl/client/${serviceConfig.getServiceForFastTrack(service)}/details/$clientId")
     .execute[Option[ClientDetailsResponse]]
 
   def createAuthorisationRequest(journey: AgentJourney)(implicit hc: HeaderCarrier, request: AgentJourneyRequest[?]): Future[String] = {

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
@@ -65,6 +65,11 @@ class ClientServiceConfigurationService @Inject()(implicit appConfig: AppConfig)
     case _ => clientService
   } else ""
 
+  // extra method to support jumping into journeys at a position where refinement of a service will already have
+  // happened and therefore we should use the service key we have in scope instead of normalising it with getServiceForForm
+  def getServiceForFastTrack(clientService: String): String =
+    if requiresRefining(clientService) then clientService else getServiceForForm(clientService)
+
   // some services may have custom not found errors
   def getNotFoundError(journeyType: AgentJourneyType, clientService: String): JourneyExitType =
     services(clientService).journeyErrors(journeyType).notFound

--- a/conf/messages
+++ b/conf/messages
@@ -182,9 +182,13 @@ clientId.PlrId.error.required=Enter your client’s  date of registration to rep
 # -------------------------------------------------------------------------------------------
 
 clientFact.HMRC-MTD-IT.postcode.label=What is your client’s postcode?
+clientFact.HMRC-MTD-IT-SUPP.postcode.label=What is your client’s postcode?
 clientFact.HMRC-MTD-IT.postcode.hint=For sole traders who are signed up to Making Tax Digital for Income Tax, use the postcode from their business address.<br /><br />For any other type of client, use their home postcode.
+clientFact.HMRC-MTD-IT-SUPP.postcode.hint=For sole traders who are signed up to Making Tax Digital for Income Tax, use the postcode from their business address.<br /><br />For any other type of client, use their home postcode.
 clientFact.HMRC-MTD-IT.postcode.error.required=Enter your client’s postcode
+clientFact.HMRC-MTD-IT-SUPP.postcode.error.required=Enter your client’s postcode
 clientFact.HMRC-MTD-IT.postcode.error.invalid=Enter a real postcode
+clientFact.HMRC-MTD-IT-SUPP.postcode.error.invalid=Enter a real postcode
 
 clientFact.PERSONAL-INCOME-RECORD.date.label=What is your client’s date of birth?
 clientFact.PERSONAL-INCOME-RECORD.date.hint=For example, 22 7 1981.
@@ -262,8 +266,11 @@ confirmClient.false=No - I need to start again
 # ________________________________________________________________________________
 
 selectAgentRole.HMRC-MTD-IT.newRelationship.header=How do you want to act for {0}?
+selectAgentRole.HMRC-MTD-IT-SUPP.newRelationship.header=How do you want to act for {0}?
 selectAgentRole.HMRC-MTD-IT.newRelationship.legend=How do you want to act for {0}?
+selectAgentRole.HMRC-MTD-IT-SUPP.newRelationship.legend=How do you want to act for {0}?
 selectAgentRole.HMRC-MTD-IT.guidance=<a href={0} class="govuk-link" target="_blank" rel="noreferrer noopener">Find out how main and supporting agents can act (opens in new tab)</a>.
+selectAgentRole.HMRC-MTD-IT-SUPP.guidance=<a href={0} class="govuk-link" target="_blank" rel="noreferrer noopener">Find out how main and supporting agents can act (opens in new tab)</a>.
 selectAgentRole.HMRC-MTD-IT.newRelationship.option=As their main agent
 selectAgentRole.HMRC-MTD-IT-SUPP.newRelationship.option=As a supporting agent
 selectAgentRole.HMRC-MTD-IT.newRelationship.hint=Main agents can carry out all tax functions for the client and submit client’s tax returns
@@ -321,6 +328,7 @@ confirmCancellation.agent-cancel-authorisation.error.required=Select ‘yes’ i
 confirmCancellation.current-status=You are currently authorised as {0} to manage {1}’s {2}.
 
 confirmCancellation.HMRC-MTD-IT.outcome=If you cancel your authorisation, you will not be able to manage Making Tax Digital for Income Tax for {0}.
+confirmCancellation.HMRC-MTD-IT-SUPP.outcome=If you cancel your authorisation, you will not be able to manage Making Tax Digital for Income Tax for {0}.
 confirmCancellation.PERSONAL-INCOME-RECORD.outcome=If you cancel this request, you will not be able to view the Income record for this client.
 confirmCancellation.HMRC-MTD-VAT.outcome=If you cancel your authorisation, you will not be able to manage their VAT for {0}.
 confirmCancellation.HMRC-TERS-ORG.outcome=If you cancel your authorisation, you will not be able to maintain a trust or an estate on behalf of {0}.
@@ -464,6 +472,7 @@ clientNotRegistered.return=Return to your authorisation requests
 # Not authorised to de-auth
 # ________________________________________________________________________________
 notAuthorised.HMRC-MTD-IT.p=This client has not authorised you to manage their Making Tax Digital for Income Tax.
+notAuthorised.HMRC-MTD-IT-SUPP.p=This client has not authorised you to manage their Making Tax Digital for Income Tax.
 notAuthorised.PERSONAL-INCOME-RECORD.p=This client has not authorised you to view their Income record.
 notAuthorised.HMRC-MTD-VAT.p=This client has not authorised you to manage their VAT.
 notAuthorised.HMRC-TERS-ORG.p=This client has not authorised you to maintain a trust or an estate.
@@ -492,6 +501,7 @@ clientInsolvent.p=Clients cannot authorise an agent on their behalf when they ar
 # ________________________________________________________________________________
 
 authorisationAlreadyExists.HMRC-MTD-IT.p1=This client has already authorised you to manage their Making Tax Digital for Income Tax.
+authorisationAlreadyExists.HMRC-MTD-IT-SUPP.p1=This client has already authorised you to manage their Making Tax Digital for Income Tax.
 authorisationAlreadyExists.PERSONAL-INCOME-RECORD.p1=This client has already authorised you to view their Income record.
 authorisationAlreadyExists.HMRC-MTD-VAT.p1=This client has already authorised you to manage their VAT.
 authorisationAlreadyExists.HMRC-TERS-ORG.p1=This client has already authorised you to maintain a trust or an estate.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
@@ -57,8 +57,6 @@ class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matcher
     "return an empty Set when service is unknown" in :
       services.getServiceKeysForUrlPart("unknown") shouldBe Set()
 
-
-
   "inferredClientType" should :
 
     "return an inferred client type for services with only one type supported" in :
@@ -69,7 +67,6 @@ class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matcher
 
     "return None for services with more than one client type supported" in :
       services.inferredClientType(HMRCMTDVAT) shouldBe None
-
 
   "allClientTypes" should :
 
@@ -176,3 +173,22 @@ class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matcher
         width = 20,
         clientIdType = "PLRID"
       ))
+
+  "getServiceForFastTrack" should:
+
+    "return the correct service for fast track deauth" in:
+
+      services.getServiceForFastTrack("HMRC-MTD-IT") shouldBe "HMRC-MTD-IT"
+      services.getServiceForFastTrack("HMRC-MTD-IT-SUPP") shouldBe "HMRC-MTD-IT"
+      services.getServiceForFastTrack("HMRC-MTD-VAT") shouldBe "HMRC-MTD-VAT"
+      services.getServiceForFastTrack("HMRC-CGT-PD") shouldBe "HMRC-CGT-PD"
+      services.getServiceForFastTrack("HMRC-PPT-ORG") shouldBe "HMRC-PPT-ORG"
+      services.getServiceForFastTrack("HMRC-PILLAR2-ORG") shouldBe "HMRC-PILLAR2-ORG"
+      services.getServiceForFastTrack("HMRC-TERS-ORG") shouldBe "HMRC-TERS-ORG"
+      // HMRC-TERSNT-ORG is arrived at usually via refinement during deauth journey
+      // this new method "getServiceForFastTrack" ensures it is preserved when found in
+      // an invitation instead of reverted to the parent form option which is HMRC-TERS-ORG
+      services.getServiceForFastTrack("HMRC-TERSNT-ORG") shouldBe "HMRC-TERSNT-ORG"
+      services.getServiceForFastTrack("PERSONAL-INCOME-RECORD") shouldBe "PERSONAL-INCOME-RECORD"
+      services.getServiceForFastTrack("HMRC-CBC-ORG") shouldBe "HMRC-CBC-ORG"
+      services.getServiceForFastTrack("HMRC-CBC-NONUK-ORG") shouldBe "HMRC-CBC-ORG"


### PR DESCRIPTION
In addition to providing the new config method for using when calling the back end for client details (using client id) there are quite a few journey pages where SUPP was not supported in messages (as the journey has only been primed for agent led deauth up until now) - just adding support for the SUPP key in the messages ensures the content is rendered without having to normalise the actual service key in the FE as well as in the BE.