### PR TITLE
APB-9292 agent-suspended and require service in exit pages

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitController.scala
@@ -34,13 +34,17 @@ class ClientExitController @Inject()(mcc: MessagesControllerComponents,
                                      clientExitPage: ClientExitPage,
                                      actions: Actions,
                                      serviceConfigurationService: ClientServiceConfigurationService,
-                                    )(implicit val executionContext: ExecutionContext,
-                                      appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
+                                    )(implicit val executionContext: ExecutionContext, appConfig: AppConfig)
+  extends FrontendController(mcc) with I18nSupport:
 
-  def showClient(exitType: ClientExitType, continueUrl: Option[RedirectUrl] = None, taxService: Option[String] = None): Action[AnyContent] = actions.clientAuthenticate.async:
+  def showClient(
+                  exitType: ClientExitType,
+                  continueUrl: Option[RedirectUrl] = None,
+                  taxService: Option[String] = None
+                ): Action[AnyContent] = actions.clientAuthenticate.async:
     implicit request =>
       val serviceKey = taxService.fold
-        (request.journey.serviceKey.getOrElse(throw RuntimeException("Required service key is missing")))
+        (request.journey.getServiceKey)
         (s => serviceConfigurationService.getServiceKeysForUrlPart(s).head)
       Future.successful(Ok(clientExitPage(
         exitType,
@@ -50,7 +54,14 @@ class ClientExitController @Inject()(mcc: MessagesControllerComponents,
         service = serviceKey
       )))
 
-  def showUnauthorised(exitType: ClientExitType, taxService: String): Action[AnyContent] = Action.async:
+  def showUnauthorised(
+                        exitType: ClientExitType,
+                        taxService: String
+                      ): Action[AnyContent] = Action.async:
     implicit request =>
       val serviceKey = serviceConfigurationService.getServiceKeysForUrlPart(taxService).head
-      Future.successful(Ok(clientExitPage(exitType, userIsLoggedIn = false, service = serviceKey)))
+      Future.successful(Ok(clientExitPage(
+        exitType,
+        userIsLoggedIn = false,
+        service = serviceKey
+      )))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
@@ -54,9 +54,17 @@ class DeclineRequestController @Inject()(mcc: MessagesControllerComponents,
         .validateInvitation(uid, clientServiceConfig.getServiceKeysForUrlPart(taxService))
         .flatMap {
           case Left(InvitationAgentSuspendedError) =>
-            Future.successful(Redirect(routes.ClientExitController.showClient(AgentSuspended, None, Some(taxService))))
+            Future.successful(Redirect(routes.ClientExitController.showClient(
+              exitType = AgentSuspended,
+              continueUrl = None,
+              taxService = Some(taxService)
+            )))
           case Left(InvitationOrAgentNotFoundError) =>
-            Future.successful(Redirect(routes.ClientExitController.showClient(NoOutstandingRequests, None, Some(taxService))))
+            Future.successful(Redirect(routes.ClientExitController.showClient(
+              exitType = NoOutstandingRequests,
+              continueUrl = None,
+              taxService = Some(taxService)
+            )))
           case Right(response) =>
             val newJourney = request.journey.copy(
               invitationId = Some(response.invitationId),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
@@ -54,9 +54,9 @@ class DeclineRequestController @Inject()(mcc: MessagesControllerComponents,
         .validateInvitation(uid, clientServiceConfig.getServiceKeysForUrlPart(taxService))
         .flatMap {
           case Left(InvitationAgentSuspendedError) =>
-            Future.successful(Redirect(routes.ClientExitController.showUnauthorised(AgentSuspended)))
+            Future.successful(Redirect(routes.ClientExitController.showClient(AgentSuspended, None, Some(taxService))))
           case Left(InvitationOrAgentNotFoundError) =>
-            Future.successful(Redirect(routes.ClientExitController.showUnauthorised(NoOutstandingRequests)))
+            Future.successful(Redirect(routes.ClientExitController.showClient(NoOutstandingRequests, None, Some(taxService))))
           case Right(response) =>
             val newJourney = request.journey.copy(
               invitationId = Some(response.invitationId),

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPage.scala.html
@@ -38,11 +38,10 @@
     userIsLoggedIn: Boolean,
     lastModifiedDate: Option[Instant] = None,
     continueUrl: Option[RedirectUrl] = None,
-    service: Option[String] = None
+    service: String
 )(implicit request: Request[AnyContent], messages: Messages, appConfig: AppConfig)
-@key = @{if (userIsLoggedIn) "clientExit" else "unauthorisedExit"}
 @serviceName = @{messages("service.name.clients")}
-@pageTitle = @{messages(s"$key.$exitType.header")}
+@pageTitle = @{messages(s"$exitType.header")}
 
 @layout(
     pageTitle,
@@ -53,13 +52,13 @@
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     @{
         exitType match {
-            case ClientExitType.AgentSuspended => agentSuspended()
+            case ClientExitType.AgentSuspended => agentSuspended(service, userIsLoggedIn)
             case ClientExitType.NoOutstandingRequests => noOutstandingRequests()
             case ClientExitType.AuthorisationRequestExpired => authorisationHasExpired(expiryDate = lastModifiedDate)
             case ClientExitType.AuthorisationRequestCancelled => authorisationHasBeenCancelled(lastModifiedDate, service)
             case ClientExitType.CannotFindAuthorisationRequest => cannotFindAuthRequest(continueUrl)
             case ClientExitType.AlreadyAcceptedAuthorisationRequest => alreadyAcceptedAuthorisationRequest(lastModifiedDate)
-            case ClientExitType.AlreadyRefusedAuthorisationRequest => alreadyRefusedAuthorisationRequest(lastModifiedDate, service.getOrElse(throw new RuntimeException("Service Key is missing")))
+            case ClientExitType.AlreadyRefusedAuthorisationRequest => alreadyRefusedAuthorisationRequest(lastModifiedDate, service)
         }
     }
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AgentSuspended.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AgentSuspended.scala.html
@@ -19,11 +19,13 @@
 
 @this()
 
-@()(implicit messages: Messages, appConfig:AppConfig)
+@(serviceKey: String, userIsLoggedIn: Boolean)(implicit messages: Messages, appConfig:AppConfig)
 @key = @{"agentSuspended"}
 
-<p class="govuk-body">@messages(s"$key.p1")</p>
+<p class="govuk-body">@messages(s"$key.p1", messages(serviceKey))</p>
 <p class="govuk-body">@messages(s"$key.p2")</p>
-
-<a id="guidanceLink" class="govuk-link"
-href='@Some(routes.SignOutController.signOut(isAgent = false).url)'>@messages(s"$key.signout-link")</a>
+@if(userIsLoggedIn) {
+ <p class="govuk-body">
+  <a class="govuk-link" href="@{routes.SignOutController.signOut(isAgent = false).url}">@messages(s"$key.signout-link")</a>
+ </p>
+}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AuthorisationHasBeenCancelled.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AuthorisationHasBeenCancelled.scala.html
@@ -23,10 +23,9 @@
 
 @this()
 
-@(expiryDate: Option[Instant], service: Option[String])(implicit messages: Messages, appConfig: AppConfig, request: Request[AnyContent])
+@(expiryDate: Option[Instant], serviceKey: String)(implicit messages: Messages, appConfig: AppConfig, request: Request[AnyContent])
 
 @key = @{"authorisationRequestCancelled"}
-@serviceKey = @{service.getOrElse(throw new RuntimeException("Service Key is missing"))}
 @date = @{expiryDate.getOrElse(throw new RuntimeException("Expiry date is missing"))}
 
 <p class="govuk-body">@messages(s"$key.p1", displayInstant(date))</p>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -34,9 +34,9 @@ GET        /authorisation-response/:uid/:taxService/consent-information         
 GET        /authorisation-response/:uid/:taxService/confirm-decline                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.DeclineRequestController.show(uid: String, taxService: String)
 POST       /authorisation-response/:uid/:taxService/confirm-decline                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.DeclineRequestController.submit(uid: String, taxService: String)
 
-GET        /authorisation-response/exit-auth/:exitType                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showClient(exitType: ClientExitType, continueUrl: Option[RedirectUrl] ?= None)
+GET        /authorisation-response/exit-auth/:exitType                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showClient(exitType: ClientExitType, continueUrl: Option[RedirectUrl] ?= None, taxService: Option[String] ?= None)
 
-GET        /authorisation-response/exit-public/:exitType                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showUnauthorised(exitType: ClientExitType)
+GET        /authorisation-response/exit-public/:exitType                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showUnauthorised(exitType: ClientExitType, taxService: String)
 
 GET        /authorisation-response/confirm-consent                                      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConfirmConsentController.show
 POST       /authorisation-response/confirm-consent                                      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConfirmConsentController.submit

--- a/conf/messages
+++ b/conf/messages
@@ -857,32 +857,28 @@ clientDeauthConfirmed.link=Manage who can deal with HMRC for you
 clientDeauthConfirmed.signOutLink=Finish and sign out
 
 # ________________________________________________________________________________
-# Unauthorised exit partials
+# Client journey exit partial headers
 # ________________________________________________________________________________
-unauthorisedExit.agent-suspended.header=You cannot appoint this tax agent
-unauthorisedExit.no-outstanding-requests.header=There are no outstanding authorisation requests for you to respond to
+
+cannot-find-authorisation-request.header=There are no requests linked to the sign-in details you used
+authorisation-request-expired.header=This authorisation request has already expired
+authorisation-request-cancelled.header=This authorisation request request has been cancelled
+agent-suspended.header=You cannot appoint this tax agent
+already-accepted-authorisation-request.header=You have already accepted this authorisation request
+already-refused-authorisation-request.header=You already refused this authorisation request
+no-outstanding-requests.header=There are no outstanding authorisation requests for you to respond to
 
 # ________________________________________________________________________________
 # You cannot appoint this tax agent (Agent suspended)
 # ________________________________________________________________________________
-agentSuspended.p1=This tax agent cannot manage your Making Tax Digital for Income Tax at this time.
+agentSuspended.p1=This tax agent cannot manage your {0} at this time.
 agentSuspended.p2=If you have any questions, contact the tax agent who sent you this request.
 agentSuspended.signout-link=Finish and sign out
 
 # ________________________________________________________________________________
 # There are no outstanding authorisation requests for you to respond to
 # ________________________________________________________________________________
-noOutstandingRequests.p1= If you think this is wrong, contact the agent who sent you the request or <a href={0} class="govuk-link" target="_blank" rel="noreferrer noopener">view your request history</a>.
-
-# ________________________________________________________________________________
-# Client journey exit partials
-# ________________________________________________________________________________
-
-clientExit.cannot-find-authorisation-request.header=There are no requests linked to the sign-in details you used
-clientExit.authorisation-request-expired.header=This authorisation request has already expired
-clientExit.authorisation-request-cancelled.header=This authorisation request request has been cancelled
-clientExit.already-accepted-authorisation-request.header=You have already accepted this authorisation request
-clientExit.already-refused-authorisation-request.header=You already refused this authorisation request
+noOutstandingRequests.p1= If you think this is wrong, contact the agent who sent you the request or <a href="{0}" class="govuk-link">view your request history</a>.
 
 # ________________________________________________________________________________
 # This authorisation request has already expired

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitControllerISpec.scala
@@ -34,6 +34,7 @@ class ClientExitControllerISpec extends ComponentSpecHelper with AuthStubs {
   val alreadyAcceptedStatus: List[InvitationStatus] = List(Accepted, DeAuthorised, PartialAuth)
 
   val testName = "Test Name"
+  val defaultTaxService = "income-tax"
 
   def testValidateInvitationResponseJson(taxService: String, status: String = "Pending"): JsObject = Json.obj(
     "invitationId" -> "AB1234567890",
@@ -64,27 +65,27 @@ class ClientExitControllerISpec extends ComponentSpecHelper with AuthStubs {
     "return 200" when {
       "the user is signed out and the agent is suspended" in {
         await(journeyService.saveJourney(journeyModel(None)))
-        val result = get(routes.ClientExitController.showUnauthorised(AgentSuspended).url)
+        val result = get(routes.ClientExitController.showUnauthorised(AgentSuspended, defaultTaxService).url)
 
         result.status shouldBe OK
       }
       "the user is signed out and there are no outstanding requests" in {
         await(journeyService.saveJourney(journeyModel(None)))
-        val result = get(routes.ClientExitController.showUnauthorised(NoOutstandingRequests).url)
+        val result = get(routes.ClientExitController.showUnauthorised(NoOutstandingRequests, defaultTaxService).url)
 
         result.status shouldBe OK
       }
       "a client is signed in and the agent is suspended" in {
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(journeyModel(None)))
-        val result = get(routes.ClientExitController.showUnauthorised(AgentSuspended).url)
+        val result = get(routes.ClientExitController.showUnauthorised(AgentSuspended, defaultTaxService).url)
 
         result.status shouldBe OK
       }
       "a client is signed in and  there are no outstanding requests" in {
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(journeyModel(None)))
-        val result = get(routes.ClientExitController.showUnauthorised(NoOutstandingRequests).url)
+        val result = get(routes.ClientExitController.showUnauthorised(NoOutstandingRequests, defaultTaxService).url)
 
         result.status shouldBe OK
       }
@@ -93,10 +94,16 @@ class ClientExitControllerISpec extends ComponentSpecHelper with AuthStubs {
 
   "the showClient action" should {
     "return 200" when {
+      "the client is authenticated and the agent is suspended" in {
+        authoriseAsClient()
+        await(journeyService.saveJourney(journeyModel(None)))
+        val result = get(routes.ClientExitController.showClient(AgentSuspended, taxService = Some(defaultTaxService)).url)
+        result.status shouldBe OK
+      }
       "the client is authenticated and the authorisation request is Cancelled" in {
         authoriseAsClient()
         await(journeyService.saveJourney(journeyModel(Some(Cancelled))))
-        val result = get(routes.ClientExitController.showClient(AuthorisationRequestCancelled).url)
+        val result = get(routes.ClientExitController.showClient(AuthorisationRequestCancelled, taxService = Some(defaultTaxService)).url)
         result.status shouldBe OK
       }
       "the client is authenticated and the authorisation request is Expired" in {

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationControllerISpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
 
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
@@ -74,72 +75,208 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
   "GET /authorisation-response/:uid/:taxService/consent-information" should {
 
     "redirect to a InsufficientEnrolments exit page when the URL part is not valid for the user enrolments" in :
-      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices("vat")))))
-      val result = get(routes.DeclineRequestController.show(testUid, "vat").url)
+      authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+      journeyService
+        .saveJourney(
+          journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some(taxServices("vat"))
+          )
+        ).futureValue
+      val result = get(
+        uri = routes.DeclineRequestController.show(
+          uid = testUid,
+          taxService = "vat"
+        ).url
+      )
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ClientExitController
-        .showClient(ClientExitType.CannotFindAuthorisationRequest, Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(testUid, "vat").url))).url
+        .showClient(
+          exitType = ClientExitType.CannotFindAuthorisationRequest,
+          continueUrl = Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(testUid, "vat").url))
+        ).url
 
     "redirect to NoOutstandingRequests exit page when the invitation data is not found" in {
-      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some("HMRC-MTD-IT"))))
+      authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+      journeyService
+        .saveJourney(
+          journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some("HMRC-MTD-IT")
+          )
+        ).futureValue
       stubPost(validateInvitationUrl, NOT_FOUND, "")
-      val result = get(routes.ConsentInformationController.show(testUid, defaultTaxService).url)
+      val result = get(
+        uri = routes.ConsentInformationController.show(
+          uid = testUid,
+          taxService = defaultTaxService
+        ).url
+      )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.NoOutstandingRequests).url
+      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        exitType = ClientExitType.NoOutstandingRequests
+      ).url
     }
 
     "redirect to AgentSuspended exit page when the invitation data is not found" in {
       authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some("HMRC-MTD-IT"))))
+      journeyService
+        .saveJourney(
+          journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some("HMRC-MTD-IT")
+          )
+        ).futureValue
       stubPost(validateInvitationUrl, FORBIDDEN, "")
-      val result = get(routes.ConsentInformationController.show(testUid, defaultTaxService).url)
+      val result = get(
+        uri = routes.ConsentInformationController.show(
+          uid = testUid,
+          taxService = defaultTaxService
+        ).url
+      )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AgentSuspended, taxService = Some(defaultTaxService)).url
+      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        exitType = ClientExitType.AgentSuspended,
+        taxService = Some(defaultTaxService)
+      ).url
     }
 
     taxServices.keySet.foreach { taxService =>
       val serviceKey: String = taxServices(taxService)
       s"Display consent information page for $taxService" in {
         authoriseAsClientWithEnrolments(serviceKey)
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(serviceKey).toString())
-        val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
+        journeyService
+          .saveJourney(
+            journey = ClientJourney(
+              journeyType = "authorisation-response",
+              serviceKey = Some(serviceKey)
+            )
+          ).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(taxService = serviceKey).toString()
+        )
+        val result = get(
+          uri = routes.ConsentInformationController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe OK
       }
       s"Redirect correctly to expired exit page for $taxService" in {
-        authoriseAsClientWithEnrolments(serviceKey)
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(serviceKey))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(serviceKey, "Expired").toString())
-        val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(
+            journey = ClientJourney(
+              journeyType = "authorisation-response",
+              serviceKey = Some(serviceKey)
+            )
+          ).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Expired"
+          ).toString()
+        )
+        val result = get(
+          uri = routes.ConsentInformationController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AuthorisationRequestExpired).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          exitType = ClientExitType.AuthorisationRequestExpired
+        ).url
       }
       s"Redirect correctly to cancelled exit page for $taxService" in {
-        authoriseAsClientWithEnrolments(serviceKey)
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(serviceKey))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Cancelled").toString())
-        val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(
+            journey = ClientJourney(
+              journeyType = "authorisation-response",
+              serviceKey = Some(serviceKey)
+            )
+          ).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Cancelled"
+          ).toString()
+        )
+        val result = get(
+          uri = routes.ConsentInformationController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AuthorisationRequestCancelled).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          exitType = ClientExitType.AuthorisationRequestCancelled
+        ).url
       }
       s"Redirect correctly to already accepted exit page for $taxService" in {
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(serviceKey))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Accepted").toString())
-        val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(
+            journey = ClientJourney(
+              journeyType = "authorisation-response",
+              serviceKey = Some(serviceKey)
+            )
+          ).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Accepted"
+          ).toString()
+        )
+        val result = get(
+          uri = routes.ConsentInformationController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AlreadyAcceptedAuthorisationRequest).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          exitType = ClientExitType.AlreadyAcceptedAuthorisationRequest
+        ).url
       }
 
       s"Redirect correctly to already refused exit page for $taxService" in {
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(serviceKey))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Rejected").toString())
-        val result = get(routes.ConsentInformationController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(
+            journey = ClientJourney(
+              journeyType = "authorisation-response",
+              serviceKey = Some(serviceKey)
+            )
+          ).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Rejected"
+          ).toString()
+        )
+        val result = get(
+          uri = routes.ConsentInformationController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AlreadyRefusedAuthorisationRequest).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          exitType = ClientExitType.AlreadyRefusedAuthorisationRequest
+        ).url
       }
     }
   }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
@@ -47,6 +47,8 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
     "trusts-and-estates" -> "HMRC-TERS-ORG",
   )
 
+  val defaultTaxService: String = "income-tax"
+
   val validateInvitationUrl = s"/agent-client-relationships/client/validate-invitation"
 
   def testValidateInvitationResponseJson(taxService: String, status: String = "Pending"): JsObject = Json.obj(
@@ -79,64 +81,75 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
       val result = get(routes.DeclineRequestController.show(testUid, "vat").url)
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ClientExitController
-        .showClient(ClientExitType.CannotFindAuthorisationRequest, Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(testUid, "vat").url))).url
+        .showClient(
+          ClientExitType.CannotFindAuthorisationRequest,
+          Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(testUid, "vat").url))
+        ).url
 
     "redirect to NoOutstandingRequests exit page when the invitation data is not found" in :
       authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some("HMRC-MTD-IT"))))
       stubPost(validateInvitationUrl, NOT_FOUND, "")
-      val result = get(routes.DeclineRequestController.show(testUid, "income-tax").url)
+      val result = get(routes.DeclineRequestController.show(testUid, defaultTaxService).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(ClientExitType.NoOutstandingRequests).url
+      result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.NoOutstandingRequests, taxService = Some(defaultTaxService)).url
 
     "redirect to AgentSuspended exit page when the agent is suspended" in :
       authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some("HMRC-MTD-IT"))))
       stubPost(validateInvitationUrl, FORBIDDEN, "")
-      val result = get(routes.DeclineRequestController.show(testUid, "income-tax").url)
+      val result = get(routes.DeclineRequestController.show(testUid, defaultTaxService).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(ClientExitType.AgentSuspended).url
+      result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AgentSuspended, taxService = Some(defaultTaxService)).url
 
     taxServices.keySet.foreach: taxService =>
 
       s"display consent information page for $taxService" in :
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService)).toString())
         val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
         result.status shouldBe OK
 
       s"redirect to expired exit page for $taxService" in :
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Expired").toString())
         val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AuthorisationRequestExpired).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          ClientExitType.AuthorisationRequestExpired
+        ).url
 
       s"redirect to cancelled exit page for $taxService" in :
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Cancelled").toString())
         val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AuthorisationRequestCancelled).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          ClientExitType.AuthorisationRequestCancelled
+        ).url
 
       s"redirect to already accepted exit page for $taxService" in :
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Accepted").toString())
         val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AlreadyAcceptedAuthorisationRequest).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          ClientExitType.AlreadyAcceptedAuthorisationRequest
+        ).url
 
       s"redirect to already refused exit page for $taxService" in :
         authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
+        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
         stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Rejected").toString())
         val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AlreadyRefusedAuthorisationRequest).url
+        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+          ClientExitType.AlreadyRefusedAuthorisationRequest
+        ).url
 
 
   "POST /authorisation-response/:uid/:taxService/confirm-decline" when :
@@ -154,7 +167,7 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel))
         givenRejectAuthorisation("ABC123", NO_CONTENT)
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ConfirmationController.show.url
@@ -162,21 +175,21 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
       "return BadRequest when there is no service in session" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel.copy(serviceKey = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no agent name in session" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel.copy(agentName = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no invitation ID in session" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel.copy(invitationId = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe BAD_REQUEST
 
@@ -185,29 +198,29 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
       "redirect to the ConsentInformation page" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ConsentInformationController.show(testUid, "income-tax").url
+        result.header("Location").value shouldBe routes.ConsentInformationController.show(testUid, defaultTaxService).url
 
       "return BadRequest when there is no service in session" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel.copy(serviceKey = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no agent name in session" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel.copy(agentName = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no invitation ID in session" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel.copy(invitationId = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe BAD_REQUEST
 
@@ -216,6 +229,6 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
       "return BadRequest" in :
         authoriseAsClientWithEnrolments("HMRC-MTD-IT")
         await(journeyService.saveJourney(baseJourneyModel))
-        val result = post(routes.DeclineRequestController.submit(testUid, "income-tax").url)
+        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
           (Map(DeclineRequestFieldName -> Seq("")))
         result.status shouldBe BAD_REQUEST

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
@@ -16,10 +16,11 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
 
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.*
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.config.AppConfig
 import uk.gov.hmrc.agentclientrelationshipsfrontend.config.Constants.DeclineRequestFieldName
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.client.ClientExitType
@@ -29,6 +30,7 @@ import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.WiremockHelper.stubPos
 import uk.gov.hmrc.agentclientrelationshipsfrontend.utils.{AgentClientRelationshipStub, AuthStubs, ComponentSpecHelper}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
+
 
 class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs with AgentClientRelationshipStub:
 
@@ -76,76 +78,183 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
   "GET /authorisation-response/:uid/:taxService/confirm-decline" should :
 
     "redirect to a InsufficientEnrolments exit page when the URL part is not valid for the user enrolments" in :
-      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response")))
-      val result = get(routes.DeclineRequestController.show(testUid, "vat").url)
+      authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+      journeyService
+        .saveJourney(
+          journey = ClientJourney(
+            journeyType = "authorisation-response"
+          )
+        ).futureValue
+      val result = get(
+        uri = routes.DeclineRequestController.show(
+          uid = testUid,
+          taxService = "vat"
+        ).url
+      )
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ClientExitController
         .showClient(
-          ClientExitType.CannotFindAuthorisationRequest,
-          Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(testUid, "vat").url))
+          exitType = ClientExitType.CannotFindAuthorisationRequest,
+          continueUrl = Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(
+            uid = testUid,
+            taxService = "vat"
+          ).url))
         ).url
 
     "redirect to NoOutstandingRequests exit page when the invitation data is not found" in :
-      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some("HMRC-MTD-IT"))))
-      stubPost(validateInvitationUrl, NOT_FOUND, "")
-      val result = get(routes.DeclineRequestController.show(testUid, defaultTaxService).url)
+      authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+      journeyService
+        .saveJourney(journey = ClientJourney(
+          journeyType = "authorisation-response",
+          serviceKey = Some("HMRC-MTD-IT")
+        )).futureValue
+      stubPost(
+        url = validateInvitationUrl,
+        status = NOT_FOUND,
+        responseBody = ""
+      )
+      val result = get(uri = routes.DeclineRequestController.show(testUid, defaultTaxService).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.NoOutstandingRequests, taxService = Some(defaultTaxService)).url
+      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        exitType = ClientExitType.NoOutstandingRequests,
+        taxService = Some(defaultTaxService)
+      ).url
 
     "redirect to AgentSuspended exit page when the agent is suspended" in :
-      authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-      await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some("HMRC-MTD-IT"))))
+      authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+      journeyService
+        .saveJourney(journey = ClientJourney(
+          journeyType = "authorisation-response",
+          serviceKey = Some("HMRC-MTD-IT")
+        )).futureValue
       stubPost(validateInvitationUrl, FORBIDDEN, "")
-      val result = get(routes.DeclineRequestController.show(testUid, defaultTaxService).url)
+      val result = get(
+        uri = routes.DeclineRequestController.show(
+          uid = testUid,
+          taxService = defaultTaxService
+        ).url
+      )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(ClientExitType.AgentSuspended, taxService = Some(defaultTaxService)).url
+      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        exitType = ClientExitType.AgentSuspended,
+        taxService = Some(defaultTaxService)
+      ).url
 
     taxServices.keySet.foreach: taxService =>
-
+      val serviceKey: String = taxServices(taxService)
       s"display consent information page for $taxService" in :
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService)).toString())
-        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some(serviceKey)
+          )).futureValue
+        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(serviceKey).toString())
+        val result = get(
+          uri = routes.DeclineRequestController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe OK
 
       s"redirect to expired exit page for $taxService" in :
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Expired").toString())
-        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some(serviceKey)
+          )).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Expired"
+          ).toString())
+        val result = get(
+          uri = routes.DeclineRequestController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ClientExitController.showClient(
-          ClientExitType.AuthorisationRequestExpired
+          exitType = ClientExitType.AuthorisationRequestExpired
         ).url
 
       s"redirect to cancelled exit page for $taxService" in :
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Cancelled").toString())
-        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some(serviceKey)
+          )).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Cancelled"
+          ).toString())
+        val result = get(
+          uri = routes.DeclineRequestController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ClientExitController.showClient(
-          ClientExitType.AuthorisationRequestCancelled
+          exitType = ClientExitType.AuthorisationRequestCancelled
         ).url
 
       s"redirect to already accepted exit page for $taxService" in :
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Accepted").toString())
-        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some(serviceKey)
+          )).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Accepted"
+          ).toString()
+        )
+        val result = get(
+          uri = routes.DeclineRequestController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ClientExitController.showClient(
-          ClientExitType.AlreadyAcceptedAuthorisationRequest
+          exitType = ClientExitType.AlreadyAcceptedAuthorisationRequest
         ).url
 
       s"redirect to already refused exit page for $taxService" in :
-        authoriseAsClientWithEnrolments(taxServices(taxService))
-        await(journeyService.saveJourney(ClientJourney(journeyType = "authorisation-response", serviceKey = Some(taxServices(taxService)))))
-        stubPost(validateInvitationUrl, OK, testValidateInvitationResponseJson(taxServices(taxService), "Rejected").toString())
-        val result = get(routes.DeclineRequestController.show(testUid, taxService).url)
+        authoriseAsClientWithEnrolments(enrolment = serviceKey)
+        journeyService
+          .saveJourney(journey = ClientJourney(
+            journeyType = "authorisation-response",
+            serviceKey = Some(serviceKey)
+          )).futureValue
+        stubPost(
+          url = validateInvitationUrl,
+          status = OK,
+          responseBody = testValidateInvitationResponseJson(
+            taxService = serviceKey,
+            status = "Rejected"
+          ).toString()
+        )
+        val result = get(
+          uri = routes.DeclineRequestController.show(
+            uid = testUid,
+            taxService = taxService
+          ).url
+        )
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ClientExitController.showClient(
           ClientExitType.AlreadyRefusedAuthorisationRequest
@@ -164,71 +273,112 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
     "the user selects 'Yes' to confirm their rejection" should :
 
       "reject the invitation and redirect to the Confirmation page" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(journey = baseJourneyModel).futureValue
         givenRejectAuthorisation("ABC123", NO_CONTENT)
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("true")))
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe SEE_OTHER
         result.header("Location").value shouldBe routes.ConfirmationController.show.url
 
       "return BadRequest when there is no service in session" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel.copy(serviceKey = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("true")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(journey = baseJourneyModel.copy(serviceKey = None)).futureValue
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no agent name in session" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel.copy(agentName = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("true")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(journey = baseJourneyModel.copy(agentName = None)).futureValue
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no invitation ID in session" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel.copy(invitationId = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("true")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(
+          journey = baseJourneyModel.copy(invitationId = None)
+        ).futureValue
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("true")))
         result.status shouldBe BAD_REQUEST
 
     "the user selects 'No' to consider giving consent" should :
 
       "redirect to the ConsentInformation page" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("false")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(journey = baseJourneyModel).futureValue
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ConsentInformationController.show(testUid, defaultTaxService).url
+        result.header("Location").value shouldBe routes.ConsentInformationController.show(
+          uid = testUid,
+          taxService = defaultTaxService
+        ).url
 
       "return BadRequest when there is no service in session" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel.copy(serviceKey = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("false")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(journey = baseJourneyModel.copy(serviceKey = None)).futureValue
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no agent name in session" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel.copy(agentName = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("false")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        journeyService.saveJourney(journey = baseJourneyModel.copy(agentName = None)).futureValue
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe BAD_REQUEST
 
       "return BadRequest when there is no invitation ID in session" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel.copy(invitationId = None)))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("false")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        await(journeyService.saveJourney(journey = baseJourneyModel.copy(invitationId = None)))
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("false")))
         result.status shouldBe BAD_REQUEST
 
     "the user does not select an option" should :
 
       "return BadRequest" in :
-        authoriseAsClientWithEnrolments("HMRC-MTD-IT")
-        await(journeyService.saveJourney(baseJourneyModel))
-        val result = post(routes.DeclineRequestController.submit(testUid, defaultTaxService).url)
-          (Map(DeclineRequestFieldName -> Seq("")))
+        authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
+        await(journeyService.saveJourney(journey = baseJourneyModel))
+        val result = post(
+          uri = routes.DeclineRequestController.submit(
+            uid = testUid,
+            taxService = defaultTaxService
+          ).url
+        )(Map(DeclineRequestFieldName -> Seq("")))
         result.status shouldBe BAD_REQUEST

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerISpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client
 
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.agentclientrelationshipsfrontend.connectors.AgentClientRelationshipsConnector
@@ -56,34 +57,86 @@ class StartControllerISpec extends ComponentSpecHelper with ScalaFutures with Au
   "GET /appoint-someone-to-deal-with-HMRC-for-you/:uid/:normalizedAgentName/:taxService" should {
     "Returns Not Found when tax service name not valid" in {
 
-      val result = get(routes.StartController.show(testUid, testNormalizedAgentName, "invalidTaxService").url)
+      val result = get(
+        uri = routes.StartController.show(
+          uid = testUid,
+          normalizedAgentName = testNormalizedAgentName,
+          taxService = "invalidTaxService"
+        ).url
+      )
       result.status shouldBe NOT_FOUND
     }
 
     "Redirect to routes.ClientExitController.show(AGENT_NOT_FOUND)" in {
 
-      stubGet(getValidateLinkResponseUrl(testUid, testNormalizedAgentName), NOT_FOUND, testValidateLinkResponseJson.toString)
+      stubGet(
+        url = getValidateLinkResponseUrl(
+          uid = testUid,
+          normalizedAgentName = testNormalizedAgentName
+        ),
+        status = NOT_FOUND,
+        body = testValidateLinkResponseJson.toString
+      )
 
-      val result = get(routes.StartController.show(testUid, testNormalizedAgentName, testTaxService).url)
+      val result = get(
+        uri = routes.StartController.show(
+          uid = testUid,
+          normalizedAgentName = testNormalizedAgentName,
+          taxService = testTaxService
+        ).url
+      )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(NoOutstandingRequests, testTaxService).url
+      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(
+        exitType = NoOutstandingRequests,
+        taxService = testTaxService
+      ).url
     }
 
     "Redirect to routes.ClientExitController.show(AGENT_SUSPENDED)" in {
 
-      stubGet(getValidateLinkResponseUrl(testUid, testNormalizedAgentName), FORBIDDEN, testValidateLinkResponseJson.toString)
+      stubGet(
+        url = getValidateLinkResponseUrl(
+          uid = testUid,
+          normalizedAgentName = testNormalizedAgentName
+        ),
+        status = FORBIDDEN,
+        body = testValidateLinkResponseJson.toString
+      )
 
-      val result = get(routes.StartController.show(testUid, testNormalizedAgentName, testTaxService).url)
+      val result = get(
+        uri = routes.StartController.show(
+          uid = testUid,
+          normalizedAgentName = testNormalizedAgentName,
+          taxService = testTaxService
+        ).url
+      )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(AgentSuspended, testTaxService).url
+      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(
+        exitType = AgentSuspended,
+        taxService = testTaxService
+      ).url
     }
 
     validTaxServiceNames.foreach { taxService =>
       s"Display start page for $taxService" in {
 
-        stubGet(getValidateLinkResponseUrl(testUid, testNormalizedAgentName), OK, testValidateLinkResponseJson.toString)
+        stubGet(
+          url = getValidateLinkResponseUrl(
+            uid = testUid,
+            normalizedAgentName = testNormalizedAgentName
+          ),
+          status = OK,
+          body = testValidateLinkResponseJson.toString
+        )
 
-        val result = get(routes.StartController.show(testUid, testNormalizedAgentName, taxService).url)
+        val result = get(
+          uri = routes.StartController.show(
+            uid = testUid,
+            normalizedAgentName = testNormalizedAgentName,
+            taxService = taxService
+          ).url
+        )
+
         result.status shouldBe OK
       }
 

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerISpec.scala
@@ -66,7 +66,7 @@ class StartControllerISpec extends ComponentSpecHelper with ScalaFutures with Au
 
       val result = get(routes.StartController.show(testUid, testNormalizedAgentName, testTaxService).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(NoOutstandingRequests).url
+      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(NoOutstandingRequests, testTaxService).url
     }
 
     "Redirect to routes.ClientExitController.show(AGENT_SUSPENDED)" in {
@@ -75,7 +75,7 @@ class StartControllerISpec extends ComponentSpecHelper with ScalaFutures with Au
 
       val result = get(routes.StartController.show(testUid, testNormalizedAgentName, testTaxService).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(AgentSuspended).url
+      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(AgentSuspended, testTaxService).url
     }
 
     validTaxServiceNames.foreach { taxService =>

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
@@ -77,7 +77,13 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for CannotFindAuthorisationRequest view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(CannotFindAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate), Some(RedirectUrl("/url")))
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = CannotFindAuthorisationRequest,
+      userIsLoggedIn = true,
+      lastModifiedDate = Some(testLastModifiedDate),
+      continueUrl = Some(RedirectUrl("/url")),
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -114,7 +120,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AuthorisationRequestExpired view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AuthorisationRequestExpired, userIsLoggedIn = true, Some(testLastModifiedDate))
+    val view: HtmlFormat.Appendable = viewTemplate(AuthorisationRequestExpired, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -139,7 +145,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AuthorisationRequestCancelled view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AuthorisationRequestCancelled, userIsLoggedIn = true, Some(testLastModifiedDate), service = Some(HMRCMTDIT))
+    val view: HtmlFormat.Appendable = viewTemplate(AuthorisationRequestCancelled, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -162,7 +168,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AlreadyAcceptedAuthorisationRequest view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AlreadyAcceptedAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate))
+    val view: HtmlFormat.Appendable = viewTemplate(AlreadyAcceptedAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -185,7 +191,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AlreadyRefusedAuthorisationRequest view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AlreadyRefusedAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate), service = Some(HMRCMTDIT))
+    val view: HtmlFormat.Appendable = viewTemplate(AlreadyRefusedAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -208,7 +214,7 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AgentSuspended view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AgentSuspended, userIsLoggedIn = false)
+    val view: HtmlFormat.Appendable = viewTemplate(AgentSuspended, userIsLoggedIn = false, service = HMRCMTDIT)
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -223,15 +229,11 @@ class ClientExitPageSpec extends ViewSpecSupport {
     "have a language switcher" in {
       doc.hasLanguageSwitch shouldBe true
     }
-
-    "have the correct link in the details component content" in {
-
-      doc.mainContent.extractLink(1).value shouldBe TestLink("Finish and sign out", "/agent-client-relationships/sign-out?isAgent=false")
-    }
+    // there should not be a sign out link as the user is not signed in...
   }
 
   "ClientExitPage for NoOutstandingRequests view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(NoOutstandingRequests, userIsLoggedIn = false)
+    val view: HtmlFormat.Appendable = viewTemplate(NoOutstandingRequests, userIsLoggedIn = false, service = HMRCMTDIT)
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
@@ -105,12 +105,18 @@ class ClientExitPageSpec extends ViewSpecSupport {
 
     "display correct links" in {
       doc.mainContent.extractLink(1).value shouldBe TestLink(
-        Expected.cannotFindAuthorisationRequestSignIn,
-        routes.SignOutController.signOut(isAgent = false, continueUrl = Some(RedirectUrl("/url"))).url
+        text = Expected.cannotFindAuthorisationRequestSignIn,
+        href = routes.SignOutController.signOut(
+          isAgent = false,
+          continueUrl = Some(RedirectUrl("/url"))
+        ).url
       )
       doc.mainContent.extractLink(2).value shouldBe TestLink(
-        Expected.cannotFindAuthorisationRequestSignOut,
-        routes.SignOutController.signOut(isAgent = false, continueUrl = None).url
+        text = Expected.cannotFindAuthorisationRequestSignOut,
+        href = routes.SignOutController.signOut(
+          isAgent = false,
+          continueUrl = None
+        ).url
       )
     }
 
@@ -120,7 +126,12 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AuthorisationRequestExpired view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AuthorisationRequestExpired, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = AuthorisationRequestExpired,
+      userIsLoggedIn = true,
+      lastModifiedDate = Some(testLastModifiedDate),
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -140,12 +151,20 @@ class ClientExitPageSpec extends ViewSpecSupport {
 
     "have the correct link in the details component content" in {
 
-      doc.mainContent.extractLink(1).value shouldBe TestLink("view your history", "/agent-client-relationships/manage-your-tax-agents#history")
+      doc.mainContent.extractLink(1).value shouldBe TestLink(
+        text = "view your history",
+        href = "/agent-client-relationships/manage-your-tax-agents#history"
+      )
     }
   }
 
   "ClientExitPage for AuthorisationRequestCancelled view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AuthorisationRequestCancelled, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = AuthorisationRequestCancelled,
+      userIsLoggedIn = true,
+      lastModifiedDate = Some(testLastModifiedDate),
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -158,8 +177,14 @@ class ClientExitPageSpec extends ViewSpecSupport {
     }
 
     "have the correct link text and hrefs" in {
-      doc.mainContent.extractLink(1).value shouldBe TestLink(Expected.authorisationRequestCancelledLinkOne, "/agent-client-relationships/manage-your-tax-agents")
-      doc.mainContent.extractLink(2).value shouldBe TestLink(Expected.authorisationRequestCancelledLinkTwo, "/agent-client-relationships/sign-out?isAgent=false")
+      doc.mainContent.extractLink(1).value shouldBe TestLink(
+        text = Expected.authorisationRequestCancelledLinkOne,
+        href = "/agent-client-relationships/manage-your-tax-agents"
+      )
+      doc.mainContent.extractLink(2).value shouldBe TestLink(
+        text = Expected.authorisationRequestCancelledLinkTwo,
+        href = "/agent-client-relationships/sign-out?isAgent=false"
+      )
     }
 
     "have a language switcher" in {
@@ -168,7 +193,12 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AlreadyAcceptedAuthorisationRequest view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AlreadyAcceptedAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = AlreadyAcceptedAuthorisationRequest,
+      userIsLoggedIn = true,
+      lastModifiedDate = Some(testLastModifiedDate),
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -185,13 +215,24 @@ class ClientExitPageSpec extends ViewSpecSupport {
     }
 
     "have the correct link text and hrefs" in {
-      doc.mainContent.extractLink(1).value shouldBe TestLink("Manage your tax agents", "/agent-client-relationships/manage-your-tax-agents")
-      doc.mainContent.extractLink(2).value shouldBe TestLink("Finish and sign out", "/agent-client-relationships/sign-out?isAgent=false")
+      doc.mainContent.extractLink(1).value shouldBe TestLink(
+        text = "Manage your tax agents",
+        href = "/agent-client-relationships/manage-your-tax-agents"
+      )
+      doc.mainContent.extractLink(2).value shouldBe TestLink(
+        text = "Finish and sign out",
+        href = "/agent-client-relationships/sign-out?isAgent=false"
+      )
     }
   }
 
   "ClientExitPage for AlreadyRefusedAuthorisationRequest view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AlreadyRefusedAuthorisationRequest, userIsLoggedIn = true, Some(testLastModifiedDate), service = HMRCMTDIT)
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = AlreadyRefusedAuthorisationRequest,
+      userIsLoggedIn = true,
+      lastModifiedDate = Some(testLastModifiedDate),
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -204,8 +245,14 @@ class ClientExitPageSpec extends ViewSpecSupport {
     }
 
     "have the correct link text and hrefs" in {
-      doc.mainContent.extractLink(1).value shouldBe TestLink(Expected.alreadyRefusedAuthorisationRequestLinkOne, "/agent-client-relationships/manage-your-tax-agents")
-      doc.mainContent.extractLink(2).value shouldBe TestLink(Expected.alreadyRefusedAuthorisationRequestLinkTwo, "/agent-client-relationships/sign-out?isAgent=false")
+      doc.mainContent.extractLink(1).value shouldBe TestLink(
+        text = Expected.alreadyRefusedAuthorisationRequestLinkOne,
+        href = "/agent-client-relationships/manage-your-tax-agents"
+      )
+      doc.mainContent.extractLink(2).value shouldBe TestLink(
+        text = Expected.alreadyRefusedAuthorisationRequestLinkTwo,
+        href = "/agent-client-relationships/sign-out?isAgent=false"
+      )
     }
 
     "have a language switcher" in {
@@ -214,7 +261,11 @@ class ClientExitPageSpec extends ViewSpecSupport {
   }
 
   "ClientExitPage for AgentSuspended view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(AgentSuspended, userIsLoggedIn = false, service = HMRCMTDIT)
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = AgentSuspended,
+      userIsLoggedIn = false,
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -229,11 +280,15 @@ class ClientExitPageSpec extends ViewSpecSupport {
     "have a language switcher" in {
       doc.hasLanguageSwitch shouldBe true
     }
-    // there should not be a sign out link as the user is not signed in...
+    // there should not be a sign out link as the user is not signed in
   }
 
   "ClientExitPage for NoOutstandingRequests view" should {
-    val view: HtmlFormat.Appendable = viewTemplate(NoOutstandingRequests, userIsLoggedIn = false, service = HMRCMTDIT)
+    val view: HtmlFormat.Appendable = viewTemplate(
+      exitType = NoOutstandingRequests,
+      userIsLoggedIn = false,
+      service = HMRCMTDIT
+    )
     val doc: Document = Jsoup.parse(view.body)
 
     "have the right title" in {
@@ -250,7 +305,10 @@ class ClientExitPageSpec extends ViewSpecSupport {
 
     "have the correct link in the details component content" in {
 
-      doc.mainContent.extractLink(1).value shouldBe TestLink("view your request history", "/agent-client-relationships/manage-your-tax-agents#history")
+      doc.mainContent.extractLink(1).value shouldBe TestLink(
+        text = "view your request history",
+        href = "/agent-client-relationships/manage-your-tax-agents#history"
+      )
     }
   }
 }


### PR DESCRIPTION
In addition to making the service description variable in the agent-suspended partial I also made the service key required in our client exit pages as it can always be resolved from the url or from the journey (if sign in) and this means partials that require it can have it without risking exceptions. Also the Finish and sign out link in the partial is now conditional on if user is signed in or not.

I also updated the h1 keys for client exit pages to not care if auth/public as they are always the same and I actually found one use case missing (auth noOutStandingRequests was triggered with raw message key as h1)