### PR TITLE
APB-9225 tell auth about organisation account type

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitController.scala
@@ -45,7 +45,7 @@ class ClientExitController @Inject()(mcc: MessagesControllerComponents,
     implicit request =>
       val serviceKey = taxService.fold
         (request.journey.getServiceKey)
-        (s => serviceConfigurationService.getServiceKeysForUrlPart(s).head)
+        (s => serviceConfigurationService.getServiceNameForUrlPart(s))
       Future.successful(Ok(clientExitPage(
         exitType,
         userIsLoggedIn = true,
@@ -59,7 +59,7 @@ class ClientExitController @Inject()(mcc: MessagesControllerComponents,
                         taxService: String
                       ): Action[AnyContent] = Action.async:
     implicit request =>
-      val serviceKey = serviceConfigurationService.getServiceKeysForUrlPart(taxService).head
+      val serviceKey = serviceConfigurationService.getServiceNameForUrlPart(taxService)
       Future.successful(Ok(clientExitPage(
         exitType,
         userIsLoggedIn = false,

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationService.scala
@@ -89,6 +89,11 @@ class ClientServiceConfigurationService @Inject()(implicit appConfig: AppConfig)
     .map((_, serviceData) => serviceData.urlPart(taxService))
     .getOrElse(Set())
 
+  def getServiceNameForUrlPart(taxService: String): String = services
+    .find(_._2.urlPart.keySet.contains(taxService))
+    .map((_, serviceData) => serviceData.serviceName)
+    .getOrElse(throw new RuntimeException(s"Cannot get service for url part $taxService"))
+
   // url parts are used in public urls to determine which service
   def getUrlPart(clientService: String): String = services(getServiceForForm(clientService)).urlPart.keys.head
 
@@ -98,6 +103,13 @@ class ClientServiceConfigurationService @Inject()(implicit appConfig: AppConfig)
     val clientTypes = services(getServiceForForm(clientService)).clientTypes
     if clientTypes.size == 1 then Some(clientTypes.head.toString) else None
   }
+
+  // we resolve the supplied url part to a service and then check the
+  // client types go see if personal is included (e.g. for OneLogin redirects)
+  def includesPersonal(urlPart: String): Boolean =
+    services(getServiceNameForUrlPart(urlPart))
+      .clientTypes
+      .contains(personal)
 
   val supportingAgentServices: Seq[String] = Seq(HMRCMTDITSUPP)
   

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmConsentPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmConsentPage.scala.html
@@ -24,8 +24,6 @@
 @this(layout: Layout,
       govukButton: GovukButton,
       govukRadios: GovukRadios,
-      govukWarningText: GovukWarningText,
-      govukDetails: GovukDetails,
       formWithCSRF: FormWithCSRF)
 
 @(form: Form[Boolean], agentRoleKey: String)(implicit request: ClientJourneyRequest[?], messages: Messages, appConfig: AppConfig)
@@ -34,7 +32,6 @@
 @agentRoleOverride = @{if appConfig.emaEnabled then agentRoleKey else "agent"}
 @serviceKey = @{request.journey.getServiceKey}
 @agentName = @{request.journey.getAgentName}
-@agentRole = @{messages(s"$key.$agentRoleOverride")}
 @agentRoleNoStrong = @{messages(s"$key.form.$agentRoleOverride")}
 @taxServiceName = @{messages(serviceKey)}
 @pageTitle = @{messages(s"$key.h1")}

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConsentInformationPage.scala.html
@@ -38,7 +38,6 @@
 @indefiniteAgentRole = @{if appConfig.emaEnabled then messages(s"indefiniteAgentRole.$serviceKey") else messages("indefiniteAgentRole.noEMA")}
 @taxServiceName = @{messages(serviceKey)}
 @removeContent = {<p class="govuk-body">@Html(messages(s"$key.section3.p1", routes.ManageYourTaxAgentsController.show.url))</p>}
-@extAgents= @{journey.existingMainAgent}
 @warningHtml= @{(journey.existingMainAgent, agentRoleKey) match {
     case (Some(exAgent), "suppAgent") if exAgent.sameAgent =>
         val text = messages(s"$key.warning.$agentRoleKey", agentName)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActionsSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActionsSpec.scala
@@ -219,6 +219,13 @@ class AuthActionsSpec extends AnyWordSpecLike with Matchers with OptionValues wi
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).value should startWith("http://localhost:9099/bas-gateway/sign-in")
 
+    "redirect a user without session to the login with accountType ORGANISATION" in:
+      val controller = failingControllerSetup(BearerTokenExpired(""))
+      val result = controller.clientAuthWithEnrolmentCheck(countryByCountryReporting)(fakeRequest)
+
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result).value should endWith("ORGANISATION")
+
     "block a client without required enrolments (can't happen in theory)" in :
       val controller = failingControllerSetup(InsufficientEnrolments(""))
       val result = controller.clientAuthWithEnrolmentCheck(incomeTax)(fakeRequest)

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/services/ClientServiceConfigurationServiceSpec.scala
@@ -192,3 +192,30 @@ class ClientServiceConfigurationServiceSpec extends AnyWordSpecLike with Matcher
       services.getServiceForFastTrack("PERSONAL-INCOME-RECORD") shouldBe "PERSONAL-INCOME-RECORD"
       services.getServiceForFastTrack("HMRC-CBC-ORG") shouldBe "HMRC-CBC-ORG"
       services.getServiceForFastTrack("HMRC-CBC-NONUK-ORG") shouldBe "HMRC-CBC-ORG"
+
+  "getServiceNameForUrlPart" should:
+
+    "return service name for valid url parts" in:
+
+      services.getServiceNameForUrlPart(incomeTax) shouldBe "HMRC-MTD-IT"
+      services.getServiceNameForUrlPart(incomeRecordViewer) shouldBe "PERSONAL-INCOME-RECORD"
+      services.getServiceNameForUrlPart(vat) shouldBe "HMRC-MTD-VAT"
+      services.getServiceNameForUrlPart(capitalGainsTaxUkProperty) shouldBe "HMRC-CGT-PD"
+      services.getServiceNameForUrlPart(plasticPackagingTax) shouldBe "HMRC-PPT-ORG"
+      services.getServiceNameForUrlPart(countryByCountryReporting) shouldBe "HMRC-CBC-ORG"
+      services.getServiceNameForUrlPart(trustsAndEstates) shouldBe "HMRC-TERS-ORG"
+      services.getServiceNameForUrlPart(pillar2) shouldBe "HMRC-PILLAR2-ORG"
+
+  "includesPersonal" should:
+
+    "return true when a service supports personal client types" in:
+      services.includesPersonal(incomeTax) shouldBe true
+      services.includesPersonal(incomeRecordViewer) shouldBe true
+      services.includesPersonal(vat) shouldBe true
+      services.includesPersonal(capitalGainsTaxUkProperty) shouldBe true
+      services.includesPersonal(plasticPackagingTax) shouldBe true
+
+    "return false when a service does not support personal client types" in:
+      services.includesPersonal(countryByCountryReporting) shouldBe false
+      services.includesPersonal(trustsAndEstates) shouldBe false
+      services.includesPersonal(pillar2) shouldBe false


### PR DESCRIPTION
I created a new method on `ClientServiceConfigurationService` to match a service with a url part in a better way than the previously used `getServiceKeysForUrlPart` - the other use case where we used the old method is in the `ClientExitController` so I updated that to use the new `getServiceNameFromUrlPart` instead too - this is more reliable than using the serviceKeys values to find the service.