### PR TITLE
APB-9424 Cleaned up client auth actions and kickout endpoints

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/Actions.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.agentclientrelationshipsfrontend.actions
 
-import play.api.mvc.{ActionBuilder, AnyContent, DefaultActionBuilder}
-import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, ClientJourneyRequest, AgentJourneyType}
+import play.api.mvc.{ActionBuilder, AnyContent, DefaultActionBuilder, Request}
+import uk.gov.hmrc.agentclientrelationshipsfrontend.models.journey.{AgentJourneyRequest, AgentJourneyType, ClientJourneyRequest}
 import uk.gov.hmrc.agentclientrelationshipsfrontend.models.AgentFastTrackRequestWithRedirectUrls
 
 import javax.inject.{Inject, Singleton}
@@ -38,9 +38,12 @@ class Actions @Inject()(
   def getFastTrackUrl: ActionBuilder[AgentFastTrackRequestWithRedirectUrls, AnyContent] =
     actionBuilder andThen authActions.agentAuthAction andThen getFastTrackUrlAction.getFastTrackUrlAction
 
-  def getClientJourney(taxService: String): ActionBuilder[ClientJourneyRequest, AnyContent] =
-    actionBuilder andThen authActions.clientAuthActionWithEnrolmentCheck(taxService) andThen getJourneyAction.clientJourneyAction
+  def clientJourney(taxService: String): ActionBuilder[ClientJourneyRequest, AnyContent] =
+    actionBuilder andThen authActions.clientAuthActionWithEnrolmentCheck(taxService) andThen getJourneyAction.clientJourneyAction(false)
 
-  def clientAuthenticate: ActionBuilder[ClientJourneyRequest, AnyContent] =
-    actionBuilder andThen authActions.clientAuthAction andThen getJourneyAction.clientJourneyAction
+  def clientJourneyRequired: ActionBuilder[ClientJourneyRequest, AnyContent] =
+    actionBuilder andThen authActions.clientAuthAction andThen getJourneyAction.clientJourneyAction(true)
+
+  def clientAuthorised: ActionBuilder[Request, AnyContent] =
+    actionBuilder andThen authActions.clientAuthAction
 }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActions.scala
@@ -89,10 +89,10 @@ class AuthActions @Inject()(val authConnector: AuthConnector,
         if userHasEnrolmentForTaxService(taxService, enrols) then
           block(request)
         else
-          Future.successful(Redirect(clientRoutes.ClientExitController.showClient(
+          Future.successful(Redirect(clientRoutes.ClientExitController.showExit(
             exitType = CannotFindAuthorisationRequest,
             continueUrl = Some(RedirectUrl(currentUrl)),
-            taxService = Some(taxService)
+            taxService = taxService
           ).url))
 
       authorised(AuthProviders(GovernmentGateway))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerController.scala
@@ -37,12 +37,12 @@ class CheckYourAnswerController @Inject()(mcc: MessagesControllerComponents,
                                           journeyService: ClientJourneyService
                                          )(implicit ec: ExecutionContext, appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
 
-  def show: Action[AnyContent] = actions.clientAuthenticate:
+  def show: Action[AnyContent] = actions.clientJourneyRequired:
     implicit request =>
       if request.journey.consent.isDefined then Ok(checkYourAnswerPage())
       else Redirect(routes.ManageYourTaxAgentsController.show.url)
 
-  def submit: Action[AnyContent] = actions.clientAuthenticate.async:
+  def submit: Action[AnyContent] = actions.clientJourneyRequired.async:
     implicit request =>
       val consentAnswer: Option[Boolean] = request.journey.consent
       val invitationId: Option[String] = request.journey.invitationId

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ClientExitController.scala
@@ -37,31 +37,26 @@ class ClientExitController @Inject()(mcc: MessagesControllerComponents,
                                     )(implicit val executionContext: ExecutionContext, appConfig: AppConfig)
   extends FrontendController(mcc) with I18nSupport:
 
-  def showClient(
-                  exitType: ClientExitType,
-                  continueUrl: Option[RedirectUrl] = None,
-                  taxService: Option[String] = None
-                ): Action[AnyContent] = actions.clientAuthenticate.async:
+  //TODO split into separate routes for each exit page
+
+  def showJourneyExit(
+                       exitType: ClientExitType
+                     ): Action[AnyContent] = actions.clientJourneyRequired.async:
     implicit request =>
-      val serviceKey = taxService.fold
-        (request.journey.getServiceKey)
-        (s => serviceConfigurationService.getServiceNameForUrlPart(s))
       Future.successful(Ok(clientExitPage(
         exitType,
-        userIsLoggedIn = true,
-        lastModifiedDate = request.journey.lastModifiedDate,
-        continueUrl = continueUrl,
-        service = serviceKey
+        lastModifiedDate = Some(request.journey.getLastModifiedDate),
+        service = request.journey.getServiceKey
       )))
 
-  def showUnauthorised(
-                        exitType: ClientExitType,
-                        taxService: String
-                      ): Action[AnyContent] = Action.async:
+  def showExit(
+                exitType: ClientExitType,
+                continueUrl: Option[RedirectUrl] = None,
+                taxService: String
+              ): Action[AnyContent] = Action.async:
     implicit request =>
-      val serviceKey = serviceConfigurationService.getServiceNameForUrlPart(taxService)
       Future.successful(Ok(clientExitPage(
         exitType,
-        userIsLoggedIn = false,
-        service = serviceKey
+        continueUrl = continueUrl,
+        service = serviceConfigurationService.getServiceNameForUrlPart(taxService)
       )))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmConsentController.scala
@@ -42,7 +42,7 @@ class ConfirmConsentController @Inject()(mcc: MessagesControllerComponents,
     case false => "agent"
   }
 
-  def show: Action[AnyContent] = actions.clientAuthenticate:
+  def show: Action[AnyContent] = actions.clientJourneyRequired:
     implicit request =>
       (request.journey.serviceKey, request.journey.agentName) match {
         case (Some(service), Some(agentName)) =>
@@ -54,7 +54,7 @@ class ConfirmConsentController @Inject()(mcc: MessagesControllerComponents,
         case _ => Redirect(routes.ManageYourTaxAgentsController.show.url)
       }
 
-  def submit: Action[AnyContent] = actions.clientAuthenticate.async:
+  def submit: Action[AnyContent] = actions.clientJourneyRequired.async:
     implicit request =>
       (request.journey.serviceKey, request.journey.agentName) match {
         case (Some(service), Some(agentName)) =>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationController.scala
@@ -37,7 +37,7 @@ class ConfirmationController @Inject()(mcc: MessagesControllerComponents,
                                       (implicit ec: ExecutionContext,
                                           appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport with Logging:
 
-  def show: Action[AnyContent] = actions.clientAuthenticate.async:
+  def show: Action[AnyContent] = actions.clientJourneyRequired.async:
     implicit request =>
       request.journey.journeyComplete match {
         case Some(invitationId) =>

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationController.scala
@@ -40,23 +40,21 @@ class ConsentInformationController @Inject()(agentClientRelationshipsConnector: 
                                              clientJourneyService: ClientJourneyService
                                             )(implicit val executionContext: ExecutionContext, appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport:
 
-  def show(uid: String, taxService: String): Action[AnyContent] = actions.getClientJourney(taxService).async:
+  def show(uid: String, taxService: String): Action[AnyContent] = actions.clientJourney(taxService).async:
     implicit journeyRequest =>
 
       agentClientRelationshipsConnector
         .validateInvitation(uid, serviceConfigurationService.getServiceKeysForUrlPart(taxService))
         .flatMap {
           case Left(InvitationAgentSuspendedError) =>
-            Future.successful(Redirect(routes.ClientExitController.showClient(
+            Future.successful(Redirect(routes.ClientExitController.showExit(
               exitType = AgentSuspended,
-              continueUrl = None,
-              taxService = Some(taxService)
+              taxService = taxService
             )))
           case Left(InvitationOrAgentNotFoundError) =>
-            Future.successful(Redirect(routes.ClientExitController.showClient(
+            Future.successful(Redirect(routes.ClientExitController.showExit(
               exitType = NoOutstandingRequests,
-              continueUrl = None,
-              taxService = Some(taxService)
+              taxService = taxService
             )))
           case Right(response) =>
             val newJourney = journeyRequest.journey.copy(
@@ -72,10 +70,10 @@ class ConsentInformationController @Inject()(agentClientRelationshipsConnector: 
               case Pending =>
                 val agentRole = determineAgentRole(newJourney.getServiceKey)
                 Ok(consentInformationPage(newJourney, agentRole))
-              case Expired => Redirect(routes.ClientExitController.showClient(AuthorisationRequestExpired))
-              case Cancelled => Redirect(routes.ClientExitController.showClient(AuthorisationRequestCancelled))
-              case Rejected => Redirect(routes.ClientExitController.showClient(AlreadyRefusedAuthorisationRequest))
-              case _ => Redirect(routes.ClientExitController.showClient(AlreadyAcceptedAuthorisationRequest))
+              case Expired => Redirect(routes.ClientExitController.showJourneyExit(AuthorisationRequestExpired))
+              case Cancelled => Redirect(routes.ClientExitController.showJourneyExit(AuthorisationRequestCancelled))
+              case Rejected => Redirect(routes.ClientExitController.showJourneyExit(AlreadyRefusedAuthorisationRequest))
+              case _ => Redirect(routes.ClientExitController.showJourneyExit(AlreadyAcceptedAuthorisationRequest))
             })
         }
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ManageYourTaxAgentsController.scala
@@ -46,7 +46,7 @@ class ManageYourTaxAgentsController @Inject()(
                                              )(implicit val executionContext: ExecutionContext, appConfig: AppConfig)
   extends FrontendController(mcc) with I18nSupport:
 
-  def show: Action[AnyContent] = actions.clientAuthenticate.async:
+  def show: Action[AnyContent] = actions.clientAuthorised.async:
     implicit request =>
       for {
         mytaData <- agentClientRelationshipsService.getManageYourTaxAgentsData()
@@ -56,7 +56,7 @@ class ManageYourTaxAgentsController @Inject()(
           )
       } yield Ok(mytaPage(serviceConfigurationService.allEnabledServices.map(s => (s, serviceConfigurationService.getUrlPart(s))).toMap, mytaData))
 
-  def showConfirmDeauth(id: String): Action[AnyContent] = actions.clientAuthenticate.async:
+  def showConfirmDeauth(id: String): Action[AnyContent] = actions.clientAuthorised.async:
     implicit request =>
       authorisationsCacheService.getAuthorisation(id).map {
         case Some(authorisation) if authorisation.deauthorised.isEmpty => Ok(confirmDeauthPage(ConfirmDeauthForm.form, authorisation))
@@ -64,7 +64,7 @@ class ManageYourTaxAgentsController @Inject()(
         case None => NotFound(pageNotFound())
       }
 
-  def submitDeauth(id: String): Action[AnyContent] = actions.clientAuthenticate.async:
+  def submitDeauth(id: String): Action[AnyContent] = actions.clientAuthorised.async:
     implicit request =>
       ConfirmDeauthForm.form.bindFromRequest().fold(
         formWithErrors => authorisationsCacheService.getAuthorisation(id).map {
@@ -91,7 +91,7 @@ class ManageYourTaxAgentsController @Inject()(
           }
       )
 
-  def deauthComplete(id: String): Action[AnyContent] = actions.clientAuthenticate.async:
+  def deauthComplete(id: String): Action[AnyContent] = actions.clientAuthorised.async:
     implicit request =>
       authorisationsCacheService.getAuthorisation(id).flatMap {
         case Some(authorisation) if authorisation.deauthorised.contains(true) => Future.successful(Ok(deauthCompletePage(authorisation)))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartController.scala
@@ -47,8 +47,8 @@ class StartController @Inject()(agentClientRelationshipsConnector: AgentClientRe
         agentClientRelationshipsConnector
           .validateLinkParts(uid, normalizedAgentName)
           .map {
-            case Left(AgentSuspendedError) => Redirect(routes.ClientExitController.showUnauthorised(AgentSuspended, taxService))
-            case Left(AgentNotFoundError) => Redirect(routes.ClientExitController.showUnauthorised(NoOutstandingRequests, taxService))
+            case Left(AgentSuspendedError) => Redirect(routes.ClientExitController.showExit(AgentSuspended, None, taxService))
+            case Left(AgentNotFoundError) => Redirect(routes.ClientExitController.showExit(NoOutstandingRequests, None, taxService))
             case Right(response) => Ok(authoriseAgentStartPage(response.name, taxService, uid))
           }
       else Future.successful(NotFound(pageNotFound()))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPage.scala.html
@@ -35,7 +35,6 @@
 
 @(
     exitType: ClientExitType,
-    userIsLoggedIn: Boolean,
     lastModifiedDate: Option[Instant] = None,
     continueUrl: Option[RedirectUrl] = None,
     service: String
@@ -52,7 +51,7 @@
     <h1 class="govuk-heading-xl">@pageTitle</h1>
     @{
         exitType match {
-            case ClientExitType.AgentSuspended => agentSuspended(service, userIsLoggedIn)
+            case ClientExitType.AgentSuspended => agentSuspended(service)
             case ClientExitType.NoOutstandingRequests => noOutstandingRequests()
             case ClientExitType.AuthorisationRequestExpired => authorisationHasExpired(lastModifiedDate, service)
             case ClientExitType.AuthorisationRequestCancelled => authorisationHasBeenCancelled(lastModifiedDate, service)

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AgentSuspended.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/clientExitPartials/AgentSuspended.scala.html
@@ -19,12 +19,14 @@
 
 @this()
 
-@(serviceKey: String, userIsLoggedIn: Boolean)(implicit messages: Messages, appConfig:AppConfig)
+@(serviceKey: String)(implicit messages: Messages, appConfig: AppConfig, request: RequestHeader)
 @key = @{"agentSuspended"}
+
+@isSignedIn  = @{request.session.get("authToken").isDefined}
 
 <p class="govuk-body">@messages(s"$key.p1", messages(serviceKey))</p>
 <p class="govuk-body">@messages(s"$key.p2")</p>
-@if(userIsLoggedIn) {
+@if(isSignedIn) {
  <p class="govuk-body">
   <a class="govuk-link" href="@{routes.SignOutController.signOut(isAgent = false).url}">@messages(s"$key.signout-link")</a>
  </p>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -34,9 +34,9 @@ GET        /authorisation-response/:uid/:taxService/consent-information         
 GET        /authorisation-response/:uid/:taxService/confirm-decline                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.DeclineRequestController.show(uid: String, taxService: String)
 POST       /authorisation-response/:uid/:taxService/confirm-decline                     uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.DeclineRequestController.submit(uid: String, taxService: String)
 
-GET        /authorisation-response/exit-auth/:exitType                                  uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showClient(exitType: ClientExitType, continueUrl: Option[RedirectUrl] ?= None, taxService: Option[String] ?= None)
+GET        /authorisation-response/exit-journey/:exitType                               uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showJourneyExit(exitType: ClientExitType)
 
-GET        /authorisation-response/exit-public/:exitType                                uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showUnauthorised(exitType: ClientExitType, taxService: String)
+GET        /authorisation-response/exit/:exitType                                       uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ClientExitController.showExit(exitType: ClientExitType, continueUrl: Option[RedirectUrl] ?= None, taxService: String)
 
 GET        /authorisation-response/confirm-consent                                      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConfirmConsentController.show
 POST       /authorisation-response/confirm-consent                                      uk.gov.hmrc.agentclientrelationshipsfrontend.controllers.client.ConfirmConsentController.submit

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConsentInformationControllerISpec.scala
@@ -91,10 +91,10 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
       )
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ClientExitController
-        .showClient(
+        .showExit(
           exitType = ClientExitType.CannotFindAuthorisationRequest,
           continueUrl = Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(testUid, "vat").url)),
-          taxService = Some("vat")
+          taxService = "vat"
         ).url
 
     "redirect to NoOutstandingRequests exit page when the invitation data is not found" in {
@@ -102,8 +102,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
       journeyService
         .saveJourney(
           journey = ClientJourney(
-            journeyType = "authorisation-response",
-            serviceKey = Some("HMRC-MTD-IT")
+            journeyType = "authorisation-response"
           )
         ).futureValue
       stubPost(validateInvitationUrl, NOT_FOUND, "")
@@ -114,9 +113,9 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
         ).url
       )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+      result.header("Location").value shouldBe routes.ClientExitController.showExit(
         exitType = ClientExitType.NoOutstandingRequests,
-        taxService = Some("income-tax")
+        taxService = "income-tax"
       ).url
     }
 
@@ -137,9 +136,10 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
         ).url
       )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+      result.header("Location").value shouldBe routes.ClientExitController.showExit(
         exitType = ClientExitType.AgentSuspended,
-        taxService = Some(defaultTaxService)
+        continueUrl = None,
+        taxService = defaultTaxService
       ).url
     }
 
@@ -191,7 +191,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AuthorisationRequestExpired
         ).url
       }
@@ -219,7 +219,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AuthorisationRequestCancelled
         ).url
       }
@@ -247,7 +247,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AlreadyAcceptedAuthorisationRequest
         ).url
       }
@@ -276,7 +276,7 @@ class ConsentInformationControllerISpec extends ComponentSpecHelper with ScalaFu
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AlreadyRefusedAuthorisationRequest
         ).url
       }

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestControllerISpec.scala
@@ -93,21 +93,20 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
       )
       result.status shouldBe SEE_OTHER
       result.header("Location").value shouldBe routes.ClientExitController
-        .showClient(
+        .showExit(
           exitType = ClientExitType.CannotFindAuthorisationRequest,
           continueUrl = Some(RedirectUrl(appConfig.appExternalUrl + routes.DeclineRequestController.show(
             uid = testUid,
             taxService = "vat"
           ).url)),
-          Some("vat")
+          "vat"
         ).url
 
     "redirect to NoOutstandingRequests exit page when the invitation data is not found" in :
       authoriseAsClientWithEnrolments(enrolment = "HMRC-MTD-IT")
       journeyService
         .saveJourney(journey = ClientJourney(
-          journeyType = "authorisation-response",
-          serviceKey = Some("HMRC-MTD-IT")
+          journeyType = "authorisation-response"
         )).futureValue
       stubPost(
         url = validateInvitationUrl,
@@ -116,9 +115,10 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
       )
       val result = get(uri = routes.DeclineRequestController.show(testUid, defaultTaxService).url)
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+      result.header("Location").value shouldBe routes.ClientExitController.showExit(
         exitType = ClientExitType.NoOutstandingRequests,
-        taxService = Some(defaultTaxService)
+        continueUrl = None,
+        taxService = defaultTaxService
       ).url
 
     "redirect to AgentSuspended exit page when the agent is suspended" in :
@@ -136,9 +136,10 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
         ).url
       )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showClient(
+      result.header("Location").value shouldBe routes.ClientExitController.showExit(
         exitType = ClientExitType.AgentSuspended,
-        taxService = Some(defaultTaxService)
+        continueUrl = None,
+        taxService = defaultTaxService
       ).url
 
     taxServices.keySet.foreach: taxService =>
@@ -180,7 +181,7 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AuthorisationRequestExpired
         ).url
 
@@ -205,7 +206,7 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AuthorisationRequestCancelled
         ).url
 
@@ -231,7 +232,7 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           exitType = ClientExitType.AlreadyAcceptedAuthorisationRequest
         ).url
 
@@ -257,7 +258,7 @@ class DeclineRequestControllerISpec extends ComponentSpecHelper with AuthStubs w
           ).url
         )
         result.status shouldBe SEE_OTHER
-        result.header("Location").value shouldBe routes.ClientExitController.showClient(
+        result.header("Location").value shouldBe routes.ClientExitController.showJourneyExit(
           ClientExitType.AlreadyRefusedAuthorisationRequest
         ).url
 

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/StartControllerISpec.scala
@@ -85,7 +85,7 @@ class StartControllerISpec extends ComponentSpecHelper with ScalaFutures with Au
         ).url
       )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(
+      result.header("Location").value shouldBe routes.ClientExitController.showExit(
         exitType = NoOutstandingRequests,
         taxService = testTaxService
       ).url
@@ -110,7 +110,7 @@ class StartControllerISpec extends ComponentSpecHelper with ScalaFutures with Au
         ).url
       )
       result.status shouldBe SEE_OTHER
-      result.header("Location").value shouldBe routes.ClientExitController.showUnauthorised(
+      result.header("Location").value shouldBe routes.ClientExitController.showExit(
         exitType = AgentSuspended,
         taxService = testTaxService
       ).url

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActionsSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/actions/AuthActionsSpec.scala
@@ -153,10 +153,10 @@ class AuthActionsSpec extends AnyWordSpecLike with Matchers with OptionValues wi
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).get shouldBe clientRoutes.ClientExitController
-        .showClient(
+        .showExit(
           ClientExitType.CannotFindAuthorisationRequest,
           Some(RedirectUrl(appConfig.appExternalUrl + fakeRequest.uri)),
-          Some("income-tax")
+          "income-tax"
         ).url
 
 
@@ -174,10 +174,10 @@ class AuthActionsSpec extends AnyWordSpecLike with Matchers with OptionValues wi
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result).get shouldBe clientRoutes.ClientExitController
-        .showClient(
+        .showExit(
           ClientExitType.CannotFindAuthorisationRequest,
           Some(RedirectUrl(appConfig.appExternalUrl + fakeRequest.uri)),
-          Some("income-record-viewer")
+          "income-record-viewer"
         ).url
 
 

--- a/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ClientExitPageSpec.scala
@@ -79,7 +79,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for CannotFindAuthorisationRequest view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = CannotFindAuthorisationRequest,
-      userIsLoggedIn = true,
       lastModifiedDate = Some(testLastModifiedDate),
       continueUrl = Some(RedirectUrl("/url")),
       service = HMRCMTDIT
@@ -128,7 +127,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for AuthorisationRequestExpired view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = AuthorisationRequestExpired,
-      userIsLoggedIn = true,
       lastModifiedDate = Some(testLastModifiedDate),
       service = HMRCMTDIT
     )
@@ -156,7 +154,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for AuthorisationRequestCancelled view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = AuthorisationRequestCancelled,
-      userIsLoggedIn = true,
       lastModifiedDate = Some(testLastModifiedDate),
       service = HMRCMTDIT
     )
@@ -190,7 +187,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for AlreadyAcceptedAuthorisationRequest view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = AlreadyAcceptedAuthorisationRequest,
-      userIsLoggedIn = true,
       lastModifiedDate = Some(testLastModifiedDate),
       service = HMRCMTDIT
     )
@@ -224,7 +220,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for AlreadyRefusedAuthorisationRequest view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = AlreadyRefusedAuthorisationRequest,
-      userIsLoggedIn = true,
       lastModifiedDate = Some(testLastModifiedDate),
       service = HMRCMTDIT
     )
@@ -258,7 +253,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for AgentSuspended view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = AgentSuspended,
-      userIsLoggedIn = false,
       service = HMRCMTDIT
     )
     val doc: Document = Jsoup.parse(view.body)
@@ -281,7 +275,6 @@ class ClientExitPageSpec extends ViewSpecSupport {
   "ClientExitPage for NoOutstandingRequests view" should {
     val view: HtmlFormat.Appendable = viewTemplate(
       exitType = NoOutstandingRequests,
-      userIsLoggedIn = false,
       service = HMRCMTDIT
     )
     val doc: Document = Jsoup.parse(view.body)


### PR DESCRIPTION
Updated client auth actions to optionally require a journey to already exist (and kick out to myta if it does not)
Added authorised client action that does not interact with journeys

Updated kickout logic to go to exit pages that do not require a client journey when we are certain one was not made.