### PR TITLE
APB-9908 Fix for Client comes back to confirmation page but relationship has already been deauthorised

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/CheckYourAnswerController.scala
@@ -60,7 +60,8 @@ class CheckYourAnswerController @Inject()(mcc: MessagesControllerComponents,
             case SubmissionSuccess =>
               journeyService.saveJourney(ClientJourney(
                 journeyType = request.journey.journeyType,
-                journeyComplete = Some(invId)
+                journeyComplete = Some(invId),
+                invitationAccepted = Some(true)
               )).map(_ => Redirect(routes.ConfirmationController.show))
             case SubmissionLocked =>
               // Ensuring we remove the leftovers from the previous lock
@@ -78,7 +79,8 @@ class CheckYourAnswerController @Inject()(mcc: MessagesControllerComponents,
           _ <- agentClientRelationshipsConnector.rejectAuthorisation(invId)
           _ <- journeyService.saveJourney(ClientJourney(
             journeyType = request.journey.journeyType,
-            journeyComplete = Some(invId)
+            journeyComplete = Some(invId),
+            invitationAccepted = Some(false)
           ))
         } yield Redirect(routes.ConfirmationController.show)
 

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationController.scala
@@ -33,17 +33,19 @@ class ConfirmationController @Inject()(mcc: MessagesControllerComponents,
                                        actions: Actions,
                                        agentClientRelationshipsService: AgentClientRelationshipsService,
                                        confirmationPage: ConfirmationPage
-                                         )
+                                      )
                                       (implicit ec: ExecutionContext,
-                                          appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport with Logging:
+                                       appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport with Logging:
 
   def show: Action[AnyContent] = actions.clientJourneyRequired.async:
     implicit request =>
-      request.journey.journeyComplete match {
-        case Some(invitationId) =>
+      (request.journey.journeyComplete, request.journey.invitationAccepted) match {
+        case (Some(invitationId), Some(invitationAccepted)) =>
           agentClientRelationshipsService.getAuthorisationRequestForClient(invitationId = invitationId).map {
+
             case Some(authorisationRequestInfo) =>
-              Ok(confirmationPage(authorisationRequestInfo))
+
+              Ok(confirmationPage(authorisationRequestInfo, invitationAccepted))
             case None =>
               throw new RuntimeException(s"Authorisation request not found for invitationId: $invitationId")
           }

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/DeclineRequestController.scala
@@ -106,7 +106,8 @@ class DeclineRequestController @Inject()(mcc: MessagesControllerComponents,
                   _ <- agentClientRelationshipsConnector.rejectAuthorisation(invId)
                   _ <- clientJourneyService.saveJourney(ClientJourney(
                     journeyType = request.journey.journeyType,
-                    journeyComplete = Some(invId)
+                    journeyComplete = Some(invId),
+                    invitationAccepted = Some(false)
                   ))
                 } yield Redirect(routes.ConfirmationController.show)
               case false => Future.successful(Redirect(routes.ConsentInformationController.show(uid, taxService)))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/models/journey/ClientJourney.scala
@@ -32,7 +32,8 @@ case class ClientJourney(
                           clientType: Option[ClientType] = None,
                           existingMainAgent: Option[ExistingMainAgent] = None,
                           journeyComplete: Option[String] = None,
-                          backendErrorResponse: Option[Boolean] = None
+                          backendErrorResponse: Option[Boolean] = None,
+                          invitationAccepted: Option[Boolean] = None
                         ) {
   def getAgentName: String = agentName.getOrElse(throw new RuntimeException("Agent Name is missing"))
   def getInvitationId: String = invitationId.getOrElse(throw new RuntimeException("Invitation Id is missing"))

--- a/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/agentclientrelationshipsfrontend/views/client/ConfirmationPage.scala.html
@@ -27,14 +27,16 @@
         govukPanel: GovukPanel
 )
 
-@(authorisationRequestInfo: AuthorisationRequestInfoForClient)(implicit request: ClientJourneyRequest[?], messages: Messages, appConfig: AppConfig)
+@(authorisationRequestInfo: AuthorisationRequestInfoForClient, invitationAccepted: Boolean)(implicit request: ClientJourneyRequest[?], messages: Messages, appConfig: AppConfig)
 
 @key = @{"clientConfirmation"}
-@decisionKey = @{authorisationRequestInfo.status match {
-    case Accepted | PartialAuth => "accepted"
-    case Rejected => "rejected"
-    case status => throw new RuntimeException(s"Cannot confirm client completion of accept/reject when status is $status")
-}}
+@decisionKey = @{
+    if(invitationAccepted) {
+        "accepted"
+    } else {
+        "rejected"
+    }
+}
 @agentName = @{authorisationRequestInfo.agentName}
 @agentRoleFor(serviceKey: String) = @{
     messages(s"agentRoleFor.$serviceKey")

--- a/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationshipsfrontend/controllers/client/ConfirmationControllerISpec.scala
@@ -54,7 +54,8 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with AuthStubs :
 
   private val completeJourney: ClientJourney = ClientJourney(
     "authorisation-response",
-    journeyComplete = Some(testInvitationId)
+    journeyComplete = Some(testInvitationId),
+    invitationAccepted = Some(true)
   )
 
   val journeyService: ClientJourneyService = app.injector.instanceOf[ClientJourneyService]


### PR DESCRIPTION
The user see an error page if they reload the browser when they on the confirmation page but the relationship has already been deauthorised. 
Changes have been made so that the client can still see the confirmation page even when when deauthorised & this also minimise console noise 